### PR TITLE
refactor: merge PYAUTO_DISABLE_CRITICAL_CAUSTICS into PYAUTO_FAST_PLOTS

### DIFF
--- a/autogalaxy/plot/plot_utils.py
+++ b/autogalaxy/plot/plot_utils.py
@@ -376,7 +376,7 @@ def _caustics_from(mass_obj, grid):
     tuple[list, list]
         ``(tangential_caustics, radial_caustics)``.
     """
-    if os.environ.get("PYAUTO_DISABLE_CRITICAL_CAUSTICS") == "1":
+    if os.environ.get("PYAUTO_FAST_PLOTS") == "1":
         return [], []
 
     from autogalaxy.operate.lens_calc import LensCalc
@@ -428,7 +428,7 @@ def _critical_curves_from(mass_obj, grid, tc=None, rc=None):
     """
     from autogalaxy.operate.lens_calc import LensCalc
 
-    if os.environ.get("PYAUTO_DISABLE_CRITICAL_CAUSTICS") == "1":
+    if os.environ.get("PYAUTO_FAST_PLOTS") == "1":
         return [], []
 
     if tc is None:

--- a/autogalaxy/util/plot_utils.py
+++ b/autogalaxy/util/plot_utils.py
@@ -376,7 +376,7 @@ def _caustics_from(mass_obj, grid):
     tuple[list, list]
         ``(tangential_caustics, radial_caustics)``.
     """
-    if os.environ.get("PYAUTO_DISABLE_CRITICAL_CAUSTICS") == "1":
+    if os.environ.get("PYAUTO_FAST_PLOTS") == "1":
         return [], []
 
     from autogalaxy.operate.lens_calc import LensCalc
@@ -428,7 +428,7 @@ def _critical_curves_from(mass_obj, grid, tc=None, rc=None):
     """
     from autogalaxy.operate.lens_calc import LensCalc
 
-    if os.environ.get("PYAUTO_DISABLE_CRITICAL_CAUSTICS") == "1":
+    if os.environ.get("PYAUTO_FAST_PLOTS") == "1":
         return [], []
 
     if tc is None:


### PR DESCRIPTION
## Summary

Fold the `PYAUTO_DISABLE_CRITICAL_CAUSTICS` plot-speedup flag into `PYAUTO_FAST_PLOTS` so a single env var governs both `tight_layout()` skipping and critical-curve/caustic overlay skipping. Every workspace and release config already set both flags together for the same purpose (cheaper plots during smoke tests and release builds) — one flag is simpler to document, set, and reason about.

Closes #339.

## API Changes

Environment variable only — no Python API changes. `PYAUTO_DISABLE_CRITICAL_CAUSTICS` is retired; set `PYAUTO_FAST_PLOTS=1` instead to skip both `tight_layout()` and critical-curve/caustic overlay computation. Callers that only set `PYAUTO_DISABLE_CRITICAL_CAUSTICS` will no longer skip overlays — they must migrate to `PYAUTO_FAST_PLOTS=1`.

Paired PyAutoBuild PR removes the retired flag from the release workflow, default env vars, and docs. A follow-up workspace sweep will remove it from the `autofit/autogalaxy/autolens` workspace `env_vars.yaml`, `run_scripts.sh`, and CLAUDE.md files.

See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/` → 811 passed (no tests reference either env var)
- [x] Functional guard test: with `PYAUTO_FAST_PLOTS=1`, both `_caustics_from` and `_critical_curves_from` short-circuit to `([], [])` from both `autogalaxy/plot/plot_utils.py` and `autogalaxy/util/plot_utils.py`.
- [x] Negative-path: without `PYAUTO_FAST_PLOTS`, the guard does not fire (falls through into `LensCalc`).
- [x] `grep -r PYAUTO_DISABLE_CRITICAL_CAUSTICS autogalaxy/` → zero matches.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed (env var)
- `PYAUTO_DISABLE_CRITICAL_CAUSTICS` — no longer recognised by `autogalaxy/plot/plot_utils.py::_caustics_from`, `_critical_curves_from`, or by the identical copies in `autogalaxy/util/plot_utils.py`.

### Changed Behaviour (env var)
- `PYAUTO_FAST_PLOTS=1` now **additionally** short-circuits critical-curve and caustic overlay computation in both `autogalaxy/plot/plot_utils.py` and `autogalaxy/util/plot_utils.py`, returning `([], [])` from `_caustics_from` and `_critical_curves_from`. Previously this flag only skipped `plt.tight_layout()` (in PyAutoArray).

### Migration
- Before: `PYAUTO_DISABLE_CRITICAL_CAUSTICS=1 PYAUTO_FAST_PLOTS=1 python script.py`
- After:  `PYAUTO_FAST_PLOTS=1 python script.py`

### Known follow-up (not in this PR)
- `autogalaxy/plot/plot_utils.py` and `autogalaxy/util/plot_utils.py` are currently **byte-identical duplicates** of each other. Both were updated here to keep them in sync; deduplicating them is worth a separate cleanup task.

</details>

Generated with [Claude Code](https://claude.com/claude-code)