### PR TITLE
Drop Binder URLs, pin Colab URLs to workspace tag 2026.4.13.6

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -1,0 +1,23 @@
+name: URL Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  url_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: repo
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          ref: main
+          path: PyAutoBuild
+      - name: Run url_check.sh
+        run: bash PyAutoBuild/autobuild/url_check.sh repo

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 PyAutoGalaxy: Open-Source Multi Wavelength Galaxy Structure & Morphology
 ========================================================================
 
-.. image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/HEAD
+.. image:: https://colab.research.google.com/assets/colab-badge.svg
+   :target: https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb
 
 .. image:: https://readthedocs.org/projects/pyautogalaxy/badge/?version=latest
    :target: https://pyautogalaxy.readthedocs.io/en/latest/?badge=latest
@@ -34,7 +34,7 @@ PyAutoGalaxy: Open-Source Multi Wavelength Galaxy Structure & Morphology
 
 `Installation Guide <https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html>`_ |
 `readthedocs <https://pyautogalaxy.readthedocs.io/en/latest/index.html>`_ |
-`Introduction on Colab <https://colab.research.google.com/github/Jammy2211/autogalaxy_workspace/blob/release/start_here.ipynb>`_
+`Introduction on Colab <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb>`_
 `HowToGalaxy <https://pyautogalaxy.readthedocs.io/en/latest/howtogalaxy/howtogalaxy.html>`_
 
 **PyAutoGalaxy** is software for analysing the morphologies and structures of galaxies:
@@ -54,7 +54,7 @@ The following links are useful for new starters:
 
 - `The PyAutoGalaxy readthedocs <https://pyautogalaxy.readthedocs.io/en/latest>`_, which includes `an overview of PyAutoGalaxy's core features <https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_1_start_here.html>`_, `a new user starting guide <https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html>`_ and `an installation guide <https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html>`_.
 
-- `The introduction Jupyter Notebook on Google Colab <https://colab.research.google.com/github/Jammy2211/autogalaxy_workspace/blob/release/start_here.ipynb>`_, where you can try **PyAutoGalaxy** in a web browser (without installation).
+- `The introduction Jupyter Notebook on Google Colab <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb>`_, where you can try **PyAutoGalaxy** in a web browser (without installation).
 
 - `The autogalaxy_workspace GitHub repository <https://github.com/Jammy2211/autogalaxy_workspace>`_, which includes example scripts and the `HowToGalaxy Jupyter notebook lectures <https://github.com/Jammy2211/autogalaxy_workspace/tree/main/notebooks/howtogalaxy>`_ which give new users a step-by-step introduction to **PyAutoGalaxy**.
 

--- a/docs/howtogalaxy/chapter_1_introduction.rst
+++ b/docs/howtogalaxy/chapter_1_introduction.rst
@@ -3,24 +3,24 @@ Chapter 1: Galaxies
 
 In chapter 1, we introduce you to galaxy morphology, structure and the core **PyAutoGalaxy** API.
 
-**Binder** links to every tutorial are included.
+**Colab** links to every tutorial are included.
 
 The chapter contains the following tutorials:
 
-`Tutorial 0: Visualization <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_1_introduction/tutorial_0_visualization.ipynb>`_
+`Tutorial 0: Visualization <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_0_visualization.ipynb>`_
 - Setting up **PyAutoGalaxy**'s visualization library.
 
-`Tutorial 1: Grids And Galaxies <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
+`Tutorial 1: Grids And Galaxies <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
 - Using grids of (y,x) coordinates with galaxies made up of light profiles.
 
-`Tutorial 2: Data <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_1_introduction/tutorial_2_data.ipynb>`_
+`Tutorial 2: Data <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_2_data.ipynb>`_
 - Simulating and inspecting telescope imaging data of a galaxy.
 
-`Tutorial 3: Fitting <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_1_introduction/tutorial_3_fitting.ipynb>`_
+`Tutorial 3: Fitting <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_3_fitting.ipynb>`_
 - Fitting data with a galaxy model.
 
-`Tutorial 4: Methods <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_1_introduction/tutorial_4_methods.ipynb>`_
+`Tutorial 4: Methods <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_4_methods.ipynb>`_
 - An overview of the different methods used to fit galaxies with.
 
-`Tutorial 5: Summary <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_1_introduction/tutorial_5_summary.ipynb>`_
+`Tutorial 5: Summary <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_5_summary.ipynb>`_
 - A summary of the chapter.

--- a/docs/howtogalaxy/chapter_2_modeling.rst
+++ b/docs/howtogalaxy/chapter_2_modeling.rst
@@ -5,27 +5,27 @@ In chapter 2, we'll take you through how to model galaxies using a non-linear se
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Non-linear Search <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_2_modeling/tutorial_1_non_linear_search.ipynb>`_
+`Tutorial 1: Non-linear Search <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_1_non_linear_search.ipynb>`_
 - How a non-linear search is used to fit a model and the concepts of a parameter space and priors.
 
-`Tutorial 2: Practicalities <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_2_modeling/tutorial_2_practicalities.ipynb>`_
+`Tutorial 2: Practicalities <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_2_practicalities.ipynb>`_
 - Practicalities of performing model-fitting, like how to inspect the results on your hard-disk.
 
-`Tutorial 3: Realism and Complexity <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_2_modeling/tutorial_3_realism_and_complexity.ipynb>`_
+`Tutorial 3: Realism and Complexity <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_3_realism_and_complexity.ipynb>`_
 - Finding a balance between realism and complexity when composing and fitting a model.
 
-`Tutorial 4: Dealing with Failure <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_2_modeling/tutorial_4_dealing_with_failure.ipynb>`_
+`Tutorial 4: Dealing with Failure <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_4_dealing_with_failure.ipynb>`_
 - What to do when PyAutoGalaxy finds an inaccurate model.
 
-`Tutorial 5: Linear Profiles <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_2_modeling/tutorial_5_linear_profiles.ipynb>`_
+`Tutorial 5: Linear Profiles <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_5_linear_profiles.ipynb>`_
 - Light profiles which capture complex morphologies in a reduced number of non-linear parameters.
 
-`Tutorial 6: Masking <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_2_modeling/tutorial_6_masking.ipynb>`_
+`Tutorial 6: Masking <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_6_masking.ipynb>`_
 - How to mask your data to improve the model.
 
-`Tutorial 7: Results <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_2_modeling/tutorial_7_results.ipynb>`_
+`Tutorial 7: Results <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_7_results.ipynb>`_
 - Overview of the results available after successfully fitting a model.
 
-`Tutorial 8: Need for Speed <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_2_modeling/tutorial_8_need_for_speed.ipynb>`_
+`Tutorial 8: Need for Speed <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_8_need_for_speed.ipynb>`_
 - How to fit complex models whilst balancing efficiency and run-time.
 

--- a/docs/howtogalaxy/chapter_3_search_chaining.rst
+++ b/docs/howtogalaxy/chapter_3_search_chaining.rst
@@ -6,11 +6,11 @@ robust modeling of large galaxy samples.
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Search Chaining <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_1_search_chaining.ipynb>`_
+`Tutorial 1: Search Chaining <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_1_search_chaining.ipynb>`_
 - Breaking the modeling procedure into a chained sequence of model-fits.
 
-`Tutorial 2: Prior Passing <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_2_prior_passing.ipynb>`_
+`Tutorial 2: Prior Passing <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_2_prior_passing.ipynb>`_
 - How the results of earlier searches are passed to later searches.
 
-`Tutorial 3: x2 Galaxies <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_3_x2_galaxies.ipynb>`_
+`Tutorial 3: x2 Galaxies <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_3_x2_galaxies.ipynb>`_
 - Modeling a dataset with two galaxies using chained searches.

--- a/docs/howtogalaxy/chapter_4_pixelizations.rst
+++ b/docs/howtogalaxy/chapter_4_pixelizations.rst
@@ -5,17 +5,17 @@ In chapter 4, we use **Pixelizations** to reconstruct complex galaxies on pixeli
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Pixelizations <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_1_pixelizations.ipynb>`_
+`Tutorial 1: Pixelizations <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_1_pixelizations.ipynb>`_
 - Creating a pixel-grid which will reconstruct a galaxy's light.
 
-`Tutorial 2: Mappers <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_2_mappers.ipynb>`_
+`Tutorial 2: Mappers <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_2_mappers.ipynb>`_
 - How a pixelization maps between the data and pixelization.
 
-`Tutorial 3: Inversions <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_3_inversions.ipynb>`_
+`Tutorial 3: Inversions <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_3_inversions.ipynb>`_
 - Inverting the mappings to reconstruct the galaxy's light.
 
-`Tutorial 4: Bayesian Regularization <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb>`_
+`Tutorial 4: Bayesian Regularization <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb>`_
 - Smoothing the source within a Bayesian framework.
 
-`Tutorial 6: Model Fit <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_6_model_fit.ipynb>`_
+`Tutorial 6: Model Fit <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_6_model_fit.ipynb>`_
 - An example modeling pipeline which uses an inversion.

--- a/docs/howtogalaxy/chapter_optional.rst
+++ b/docs/howtogalaxy/chapter_optional.rst
@@ -5,12 +5,12 @@ This chapter contains optional tutorials expanding on different aspects of how *
 
 The chapter contains the following tutorials:
 
-`Tutorial: Mass Profiles  <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_optional/tutorial_mass_profiles.ipynb>`_
+`Tutorial: Mass Profiles  <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_optional/tutorial_mass_profiles.ipynb>`_
 - A description of mass profiles implemented in PyAutoGalaxy, which are currently only used by its child project PyAutoLens.
 
-`Tutorial: Sub-grids  <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_optional/tutorial_sub_grids.ipynb>`_
+`Tutorial: Sub-grids  <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_optional/tutorial_sub_grids.ipynb>`_
 - Use sub-grids to perform more accurate and precise calculations.
 
-`Tutorial: Searches  <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=notebooks/howtogalaxy/chapter_optional/tutorial_searches.ipynb>`_
+`Tutorial: Searches  <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_optional/tutorial_searches.ipynb>`_
 - Alternative non-linear searches to sample parameter space.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ The following links are useful for new starters:
 
 - `The PyAutoGalaxy readthedocs <https://pyautogalaxy.readthedocs.io/en/latest/>`_, which includes `an overview of PyAutoGalaxy's core features <https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_1_start_here.html>`_, `a new user starting guide <https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html>`_ and `an installation guide <https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html>`_.
 
-- `The introduction Jupyter Notebook on Binder <https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release?filepath=start_here.ipynb>`_, where you can try **PyAutoGalaxy** in a web browser (without installation).
+- `The introduction Jupyter Notebook on Colab <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb>`_, where you can try **PyAutoGalaxy** in a web browser (without installation).
 
 - `The autogalaxy_workspace GitHub repository <https://github.com/Jammy2211/autogalaxy_workspace>`_, which includes example scripts and the `HowToGalaxy Jupyter notebook lectures <https://github.com/Jammy2211/autogalaxy_workspace/tree/main/notebooks/howtogalaxy>`_ which give new users a step-by-step introduction to **PyAutoGalaxy**.
 

--- a/docs/overview/overview_2_new_user_guide.rst
+++ b/docs/overview/overview_2_new_user_guide.rst
@@ -29,13 +29,13 @@ environment with all the required dependencies already installed.
 This is a great way to get started quickly without needing to install **PyAutoGalaxy** on your own machine,
 so you can check it is the right software for you before going through the installation process:
 
-- `imaging/start_here.ipynb <https://colab.research.google.com/github/Jammy2211/autogalaxy_workspace/blob/release/notebooks/imaging/start_here.ipynb>`_:
+- `imaging/start_here.ipynb <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/imaging/start_here.ipynb>`_:
   Galaxy modeling with CCD imaging (e.g. Hubble, James Webb, ground-based telescopes).
 
-- `interferometer/start_here.ipynb <https://colab.research.google.com/github/Jammy2211/autogalaxy_workspace/blob/release/notebooks/interferometer/start_here.ipynb>`_:
+- `interferometer/start_here.ipynb <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/interferometer/start_here.ipynb>`_:
   Galaxy modeling with interferometer data (e.g. ALMA), fitting directly in the uv-plane.
 
-- `multi_band/start_here.ipynb <https://colab.research.google.com/github/Jammy2211/autogalaxy_workspace/blob/release/notebooks/multi/start_here.ipynb>`_:
+- `multi_band/start_here.ipynb <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/multi/start_here.ipynb>`_:
   Multi-band galaxy modeling to study colour gradients and wavelength-dependent structure.
 
 Still Unsure?

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -75,7 +75,7 @@ massively parallel model-fitting and an SQLite3 database that allows large suite
 queried and analysed. Accompanying `PyAutoGalaxy` is the [autogalaxy workspace](https://github.com/Jammy2211/autogalaxy_workspace), 
 which includes example scripts, datasets and the `HowToGalaxy` lectures in Jupyter notebook format which introduce 
 non-experts to studies of galaxy morphology using `PyAutoGalaxy`. Readers can try `PyAutoGalaxy` right now by going 
-to [the introduction Jupyter notebook on Binder](https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/release) or 
+to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb) or 
 checkout the [readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/) for a complete overview of `PyAutoGalaxy`'s 
 features.
 
@@ -156,7 +156,7 @@ contains example scripts for modeling and simulating galaxies and tutorials on h
 interferometer datasets before a `PyAutoGalaxy` analysis. Also included are the `HowToGalaxy` tutorials, a four-chapter 
 lecture series composed of over 20 Jupyter notebooks aimed at non-experts, introducing them to galaxy morphology 
 analysis, Bayesian inference and teaching them how to use `PyAutoGalaxy` for scientific study. The lectures 
-are available on [Binder](https://mybinder.org/v2/gh/Jammy2211/autogalaxy_workspace/HEAD) and may therefore be 
+are available on [Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb) and may therefore be 
 taken without a local `PyAutoGalaxy` installation.
 
 # Software Citations


### PR DESCRIPTION
## Summary

Drop all `mybinder.org` URLs in favour of Google Colab. Pin every Colab URL to the
date-based workspace tag (currently `2026.4.13.6`) so links stay aligned with the
PyPI-released library that users will have installed. Rewrite the GitHub owner
from `Jammy2211` to `PyAutoLabs`.

## What changed

- **URL rewrites** across `*.rst`, `*.md`, `*.ipynb`, `*.py`:
  - `mybinder.org/v2/gh/Jammy2211/<ws>/release?filepath=<path>` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
  - `mybinder.org/v2/gh/Jammy2211/<ws>/HEAD` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/start_here.ipynb`
  - `colab…/Jammy2211/<ws>/blob/release/<path>` → `colab…/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
- **Badge swap**: Binder badge images replaced with the official Colab badge
  (`colab-badge.svg`); RST `|binder|` substitution renamed to `|colab|`.
- **Prose cleanup**: every "Binder" link caption / sentence rewritten to "Colab"
  (case-preserving) so link text matches link target.

## Release-pipeline integration

The release workflow in PyAutoBuild (#49, merged) now invokes
`bump_colab_urls.sh <new-tag>` against this repo on every release, so the pinned
tag advances automatically. No manual maintenance is required after this PR.

## Regression guard

Adds `.github/workflows/url_check.yml` which runs PyAutoBuild's
`autobuild/url_check.sh` on every push and pull request. Re-introducing any
`mybinder.org` URL, `Jammy2211/` Colab owner, or `/blob/release/` Colab ref will
fail CI.

## Test Plan
- [ ] `url_check.yml` workflow passes on this PR
- [ ] Spot-check a Colab URL by clicking through to confirm the notebook loads at the pinned tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
