### PR TITLE
fix: Richardson-extrapolate LensCalc numpy Hessian for JAX-path parity

### DIFF
--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -359,9 +359,11 @@ class LensCalc:
 
         Two computational paths are available, selected via the `xp` parameter:
 
-        - **NumPy** (``xp=np``, default): finite-difference approximation. Deflection angles are
-          evaluated at four shifted positions around each grid coordinate (±y, ±x) and the
-          central difference is taken. JAX is not imported.
+        - **NumPy** (``xp=np``, default): 2-point central finite-difference approximation,
+          Richardson-extrapolated at step sizes ``h`` and ``h/2`` and combined as
+          ``(4 * H(h/2) - H(h)) / 3``. This cancels the leading ``O(h^2)`` truncation term,
+          giving ``O(h^4)`` accuracy and matching the JAX path to float64 precision. JAX is
+          not imported.
 
         - **JAX** (``xp=jnp``): exact derivatives via ``jax.jacfwd`` applied to
           ``deflections_yx_scalar``, vectorised over the grid with ``jnp.vectorize``.
@@ -377,8 +379,21 @@ class LensCalc:
             used and the type of the returned arrays.
         """
         if xp is np:
-            return self._hessian_via_finite_difference(grid=grid)
+            return self._hessian_via_richardson(grid=grid)
         return self._hessian_via_jax(grid=grid, xp=xp)
+
+    def _hessian_via_richardson(self, grid, buffer: float = 0.01) -> Tuple:
+        yy_h, xy_h, yx_h, xx_h = self._hessian_via_finite_difference(
+            grid=grid, buffer=buffer
+        )
+        yy_h2, xy_h2, yx_h2, xx_h2 = self._hessian_via_finite_difference(
+            grid=grid, buffer=buffer / 2.0
+        )
+        hessian_yy = (4.0 * yy_h2 - yy_h) / 3.0
+        hessian_xy = (4.0 * xy_h2 - xy_h) / 3.0
+        hessian_yx = (4.0 * yx_h2 - yx_h) / 3.0
+        hessian_xx = (4.0 * xx_h2 - xx_h) / 3.0
+        return hessian_yy, hessian_xy, hessian_yx, hessian_xx
 
     def _hessian_via_jax(self, grid, xp) -> Tuple:
         import jax

--- a/test_autogalaxy/operate/test_deflections.py
+++ b/test_autogalaxy/operate/test_deflections.py
@@ -102,10 +102,10 @@ def test__hessian_from__diagonal_grid__correct_values():
     od = LensCalc.from_mass_obj(mp)
     hessian_yy, hessian_xy, hessian_yx, hessian_xx = od.hessian_from(grid=grid)
 
-    assert hessian_yy == pytest.approx(np.array([1.3883822, 0.694127]), 1.0e-4)
-    assert hessian_xy == pytest.approx(np.array([-1.388124, -0.694094]), 1.0e-4)
-    assert hessian_yx == pytest.approx(np.array([-1.388165, -0.694099]), 1.0e-4)
-    assert hessian_xx == pytest.approx(np.array([1.3883824, 0.694127]), 1.0e-4)
+    assert hessian_yy == pytest.approx(np.array([1.3882113, 0.6941056]), 1.0e-4)
+    assert hessian_xy == pytest.approx(np.array([-1.3882113, -0.6941056]), 1.0e-4)
+    assert hessian_yx == pytest.approx(np.array([-1.3882113, -0.6941056]), 1.0e-4)
+    assert hessian_xx == pytest.approx(np.array([1.3882113, 0.6941056]), 1.0e-4)
 
 
 def test__hessian_from__axis_aligned_grid__correct_values():
@@ -152,8 +152,51 @@ def test__magnification_2d_via_hessian_from():
     od = LensCalc.from_mass_obj(mp)
     magnification = od.magnification_2d_via_hessian_from(grid=grid)
 
-    assert magnification.in_list[0] == pytest.approx(-0.56303, 1.0e-4)
-    assert magnification.in_list[1] == pytest.approx(-2.57591, 1.0e-4)
+    assert magnification.in_list[0] == pytest.approx(-0.5629291, 1.0e-4)
+    assert magnification.in_list[1] == pytest.approx(-2.575917, 1.0e-4)
+
+
+def test__hessian_from__np_richardson_matches_jax_jacfwd_to_float64():
+    import jax.numpy as jnp
+
+    grid = ag.Grid2DIrregular(values=[(0.5, 0.5), (1.0, 1.0), (0.7, -0.3)])
+
+    mp = ag.mp.Isothermal(
+        centre=(0.0, 0.0), ell_comps=(0.05, -0.111111), einstein_radius=1.5
+    )
+
+    od = LensCalc.from_mass_obj(mp)
+
+    np_hess = od.hessian_from(grid=grid, xp=np)
+    jnp_hess = od.hessian_from(grid=grid, xp=jnp)
+
+    for np_component, jnp_component in zip(np_hess, jnp_hess):
+        np.testing.assert_allclose(
+            np.asarray(np_component),
+            np.asarray(jnp_component),
+            rtol=1.0e-8,
+        )
+
+
+def test__magnification_2d_via_hessian_from__np_jnp_agree_to_float64():
+    import jax.numpy as jnp
+
+    grid = ag.Grid2DIrregular(values=[(0.5, 0.5), (1.0, 1.0), (0.7, -0.3)])
+
+    mp = ag.mp.Isothermal(
+        centre=(0.0, 0.0), ell_comps=(0.05, -0.111111), einstein_radius=1.5
+    )
+
+    od = LensCalc.from_mass_obj(mp)
+
+    np_mag = od.magnification_2d_via_hessian_from(grid=grid, xp=np)
+    jnp_mag = od.magnification_2d_via_hessian_from(grid=grid, xp=jnp)
+
+    np.testing.assert_allclose(
+        np.asarray(np_mag.array),
+        np.asarray(jnp_mag),
+        rtol=1.0e-7,
+    )
 
 
 def test__tangential_critical_curve_list_from__radius_matches_einstein_radius():


### PR DESCRIPTION
## Summary

`LensCalc.hessian_from` on the `xp=np` path used a 2-point central finite
difference with `buffer=0.01` — truncation error `O(h²) ≈ 1e-4`. The `xp=jnp`
path uses exact `jax.jacfwd` autodiff. At near-critical points the ~1e-4
error in the Hessian was amplified by the near-zero Jacobian determinant
into ~5e-4 relative errors in magnifications, producing ~0.1% log-likelihood
drift in the point-source full-pipeline JIT.

Closes the accuracy gap generically with **Richardson extrapolation** on the
existing stencil: evaluate `_hessian_via_finite_difference` at `h` and `h/2`,
combine each Hessian component as `(4·H(h/2) − H(h))/3`. This cancels the
leading `O(h²)` term, leaving `O(h⁴) ≈ 1e-8` — float64 parity with the JAX
path. Costs 2× the deflection evaluations (4 → 8 per grid); negligible
compared to a non-linear search iteration. No mass-profile API change.

Fixes the downstream ~0.1% log-likelihood drift flagged in
`autolens_workspace_developer/jax_profiling/point_source/source_plane.py`.

## API Changes

None — internal numerics change. Public `LensCalc.hessian_from` signature
and return structure are unchanged. The numpy path now yields O(h⁴)-accurate
results instead of O(h²), so callers observe tighter agreement with the JAX
path (existing `rtol=1e-4` tests continue to pass; some hardcoded expected
values updated to match the new, more accurate truth).

See full details below.

## Test Plan
- [x] `test_autogalaxy/operate/` — 41 passed (including 2 new np/jnp parity tests)
- [x] Full `test_autogalaxy/` — 836 passed
- [ ] Downstream: `autolens_workspace_developer` follow-up PR tightens
      `point_source/source_plane.py` regression assertion to `rtol=1e-4`
      against the new correct `EXPECTED_LOG_LIKELIHOOD_SOURCE_PLANE` truth.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None.

### Added
- `LensCalc._hessian_via_richardson(self, grid, buffer=0.01)` — private helper
  that Richardson-combines `_hessian_via_finite_difference` at `h` and `h/2`.

### Renamed
None.

### Changed Signature
None.

### Changed Behaviour
- `LensCalc.hessian_from(grid, xp=np)` — numpy path truncation error improved
  from `O(h²) ≈ 1e-4` to `O(h⁴) ≈ 1e-8`. Matches the JAX path (`xp=jnp`,
  exact `jax.jacfwd`) to float64 precision. Return shape and types unchanged.
- Knock-on: `convergence_2d_via_hessian_from`, `shear_yx_2d_via_hessian_from`,
  `magnification_2d_via_hessian_from`, and `jacobian_from` on the numpy path
  all inherit the accuracy improvement. All still return the same autoarray
  wrappers with the same shapes.

### Migration
No user-facing migration required. Downstream code relying on the old
`O(h²)` truncation error baked into hardcoded expected values (e.g.
workspace regression constants) will need to be updated to the new,
more accurate truth.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)