### PR TITLE
fix: skip degenerate critical curves instead of tracing phantom noise

### DIFF
--- a/autogalaxy/config/visualize/general.yaml
+++ b/autogalaxy/config/visualize/general.yaml
@@ -5,7 +5,7 @@ general:
   log10_min_value: 1.0e-4
   log10_max_value: 1.0e99
   zoom_around_mask: true
-  critical_curves_method: zero_contour
+  critical_curves_method: marching_squares
 inversion:
   reconstruction_vmax_factor: 0.5
   total_mappings_pixels: 8

--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -625,6 +625,10 @@ class LensCalc:
         """
         tangential_eigen_values = self.tangential_eigen_value_from(grid=grid)
 
+        vals = tangential_eigen_values.native
+        if vals.min() > -1e-6 or vals.max() < 1e-6:
+            return []
+
         return self.contour_list_from(grid=grid, contour_array=tangential_eigen_values)
 
     @evaluation_grid
@@ -650,6 +654,10 @@ class LensCalc:
             critical curve to be computed more accurately using a higher resolution grid.
         """
         radial_eigen_values = self.radial_eigen_value_from(grid=grid)
+
+        vals = radial_eigen_values.native
+        if vals.min() > -1e-6 or vals.max() < 1e-6:
+            return []
 
         return self.contour_list_from(grid=grid, contour_array=radial_eigen_values)
 


### PR DESCRIPTION
## Summary
Revert the default ``critical_curves_method`` back to ``marching_squares``. Add a sign-change gate on the eigenvalue grid inside ``tangential_critical_curve_list_from`` and ``radial_critical_curve_list_from``: if the eigenvalue never straddles zero, return ``[]`` instead of letting marching_squares fabricate a jaggedy noise polygon.

For slope=2 singular isothermal (and above), the radial eigenvalue is analytically always 1 — no real zero crossing, no physical radial critical curve. The gate returns [] so nothing is plotted, which is correct.

This also sidesteps a secondary bug hit on supercomputer runs after #355: zero_contour could raise under JAX tracing during model-fit visualization, and a broad except Exception in autolens.imaging.plot.fit_imaging_plots._compute_critical_curve_lines swallowed it, dropping both tangential and radial curves from every image. The silent-swallow is orthogonal and worth its own PR, but reverting to marching_squares restores the pre-regression behaviour immediately.

## API Changes
None — internal changes only. Both functions keep the same signature and return type; they now return [] (already a valid List[Grid2DIrregular] value) in the degenerate case.
See full details below.

## Test Plan
- [x] python -m pytest test_autogalaxy/ — 836 passed, 0 failed
- [ ] Inspect a model-fit run visualization for slope=2 isothermal — confirm no phantom radial caustic
- [ ] Inspect a slope<2 PowerLaw run — confirm radial caustic still drawn

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- LensCalc.tangential_critical_curve_list_from(grid, pixel_scale): now returns [] when the tangential eigenvalue grid does not straddle zero (min > -1e-6 or max < 1e-6), instead of returning a spurious marching-squares contour.
- LensCalc.radial_critical_curve_list_from(grid, pixel_scale): same gate for the radial eigenvalue. Fixes the slope>=2 isothermal case where the radial eigenvalue is analytically always positive and marching-squares was returning noise polygons.

### Config
- autogalaxy/config/visualize/general.yaml: critical_curves_method reverted from zero_contour back to marching_squares.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)