### PR TITLE
feat: stable pytree_token on LightProfileLinear for jax.jit round-trip

### DIFF
--- a/autogalaxy/profiles/light/linear/abstract.py
+++ b/autogalaxy/profiles/light/linear/abstract.py
@@ -13,6 +13,7 @@ The `LightProfileLinearObjFuncList` subclass additionally supports regularizatio
 intensities to be penalized by a smoothness prior.
 """
 import inspect
+import itertools
 import numpy as np
 from typing import Dict, List, Optional
 
@@ -44,6 +45,22 @@ class LightProfileLinear(LightProfile):
     This inheritance is used throughout the `galaxy.py`, `tracer.py` and other modules to extract linear light
     profiles when performing a fit to data.
     """
+
+    _pytree_token_counter = itertools.count()
+    __exclude_identifier_fields__ = ("pytree_token",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pytree_token = next(LightProfileLinear._pytree_token_counter)
+
+    def __hash__(self):
+        return self.pytree_token
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, LightProfileLinear)
+            and self.pytree_token == other.pytree_token
+        )
 
     @property
     def regularization(self):


### PR DESCRIPTION
## Summary

Makes `linear_light_profile_intensity_dict` survive a `jax.jit` round-trip. Previously, any model containing a `LightProfileLinear` (e.g. `al.lp_linear.Gaussian`, `al.lmp_linear.GaussianGradient`) would `KeyError` in the visualization path because the dict is identity-keyed and pytree unflatten produces fresh `cls.__new__()` objects with new `id()` values.

Fix: attach a monotonic `pytree_token` to every `LightProfileLinear` instance and route `__hash__` / `__eq__` through it. Because the name has no leading underscore, PyAutoFit's `register_model` preserves it as `attr_const` across pytree flatten/unflatten — the token rides the round-trip and dict keys stay stable.

Companion PR in PyAutoLens fixes a test whose pre-existing off-by-one bug was exposed by the new eq.

## API Changes

`LightProfileLinear` now has token-based equality: two instances compare equal only if they are the same object. Previously, `GeometryProfile.__eq__` compared `__dict__` structurally, so two `LightProfileLinear()` calls with the same parameters compared equal. Any downstream code relying on structural equality of `LightProfileLinear` instances will need adjustment (one such test was found in PyAutoLens and fixed in its companion PR).

New `pytree_token` attribute on every `LightProfileLinear` instance. Excluded from PyAutoFit's model `unique_id` via `__exclude_identifier_fields__` — regression identifier `5a3c480de681f6958048b22b3db8ecf9` on `multi_galaxy_mge.py` verified unchanged.

See full details below.

## Test Plan
- [x] PyAutoGalaxy test suite: 836 passed
- [x] PyAutoLens test suite: 252 passed (with companion PR)
- [x] `autolens_workspace_test/scripts/model_composition/multi_galaxy_mge.py` identifier unchanged
- [x] `autolens_workspace_test/scripts/imaging/modeling_visualization_jit.py` end-to-end: `fit.png` lands under MGE-linear output, no `KeyError`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `LightProfileLinear.pytree_token` — monotonic integer assigned in `__init__` via `itertools.count()`. Part of the public `__dict__` (no leading underscore) so PyAutoFit's pytree registration preserves it across flatten/unflatten.
- `LightProfileLinear._pytree_token_counter` — class-level `itertools.count()` driving the token sequence.
- `LightProfileLinear.__exclude_identifier_fields__ = ("pytree_token",)` — declares that `pytree_token` does not participate in PyAutoFit's identifier hash.
- `LightProfileLinear.__init__(*args, **kwargs)` — forwards to `super().__init__` then assigns `pytree_token`. Previously relied on inherited `LightProfile.__init__`.

### Changed Behaviour
- `LightProfileLinear.__hash__` — now returns `self.pytree_token` (previously inherited `id(self)`-based hash from `GeometryProfile`).
- `LightProfileLinear.__eq__` — now token-based: `isinstance(other, LightProfileLinear) and self.pytree_token == other.pytree_token`. Previously inherited `GeometryProfile.__eq__` which compared `__dict__` structurally. Two `LightProfileLinear()` calls with identical parameters are no longer `==`.

### Migration
- If any downstream code relied on structural equality of `LightProfileLinear` instances, use `type(a) is type(b) and vars(a) == vars(b)` explicitly instead of `a == b`.

</details>

Closes PyAutoLabs/PyAutoLens#448