### PR TITLE
feat: Delaunay-pixelization JIT round-trip support in galaxy→inversion path

### DIFF
--- a/autogalaxy/galaxy/to_inversion.py
+++ b/autogalaxy/galaxy/to_inversion.py
@@ -425,6 +425,22 @@ class GalaxiesToInversion(AbstractToInversion):
             except (AttributeError, KeyError, TypeError):
                 image_plane_mesh_grid = None
 
+            if image_plane_mesh_grid is None:
+                # Fallback for JAX JIT: after jax.jit unflatten the galaxy instances
+                # stored as keys in ``adapt_images`` are stale (different Python objects
+                # from those in the current tracer), so the dict key lookup above fails
+                # and yields None.  When the dict contains exactly one mesh-grid entry,
+                # take that single value by insertion order — this is always correct in
+                # the one-pixelised-source case (Delaunay/Hilbert image-mesh fits).
+                # fit-imaging-pytree-delaunay
+                try:
+                    dict_ = self.adapt_images.galaxy_image_plane_mesh_grid_dict
+                    vals = list(dict_.values()) if dict_ else []
+                    if len(vals) == 1:
+                        image_plane_mesh_grid = vals[0]
+                except (AttributeError, TypeError, KeyError):
+                    pass
+
             image_plane_mesh_grid_list.append(image_plane_mesh_grid)
 
         return image_plane_mesh_grid_list


### PR DESCRIPTION
## Summary

Enables ``jax.jit(analysis.fit_from)`` to succeed for models with a ``Delaunay``
pixelization source + ``Hilbert`` image-mesh + ``AdaptSplit`` regularization. Without
this change the JIT path raises ``AttributeError: 'NoneType' object has no attribute
'array'`` inside ``GalaxiesToInversion.image_plane_mesh_grid_list``, because the
``Galaxy`` keys in ``adapt_images.galaxy_image_plane_mesh_grid_dict`` are the
original Python objects and the traced ``Galaxy`` is a fresh instance produced by
pytree unflatten — identity-keyed dict lookup fails.

## API Changes

Behaviour-only change in ``GalaxiesToInversion.image_plane_mesh_grid_list``: when
the galaxy-identity-keyed mesh-grid dict lookup returns ``None`` and the dict
contains exactly one entry, that entry is now used by insertion order.

No public signature changes. NumPy path is unaffected (it never hit the fallback).

See full details below.

## Test Plan

- [x] ``pytest test_autogalaxy/ -q --ignore=test_autogalaxy/aggregator`` — 836 passed
- [x] ``scripts/jax_likelihood_functions/imaging/delaunay_pytree.py`` PASSes —
  NumPy and JIT log_likelihoods agree to rtol ~4e-15
- [x] Already-shipped pytree variants (lp, rectangular, mge_group) still pass

## Upstream PR

None — this ships as a standalone library change.

## Follow-up

The one-entry fallback is a deliberately narrow workaround. It is correct for the
current PoC (single pixelised source) but silently picks the wrong grid when there
are two or more pixelised sources. The principled fix — attach ``pytree_token`` to
``Galaxy`` mirroring ``LightProfileLinear`` so identity survives pytree round-trips —
is filed at ``admin_jammy/prompt/autolens/galaxy_pytree_token.md`` in the workspace
repo and should land before any multi-source-pixelization JIT variant is added to
the queue (e.g. ``fit_imaging_pytree_delaunay_mge.md`` — item 10 in the queue).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- ``GalaxiesToInversion.image_plane_mesh_grid_list`` —
  when ``adapt_images.galaxy_image_plane_mesh_grid_dict[galaxy]`` returns ``None``
  (because the ``Galaxy`` instance has been reconstructed by a pytree unflatten
  cycle and no longer has identity-equality with the dict's keys), the method
  now falls back to the single value in the dict when the dict has length 1.
  Previously this case appended ``None`` to the result list, leading to a crash
  downstream when the mesh grid was accessed.

### Rationale
- Unblocks the Delaunay-pixelization PoC for ``jax.jit(analysis.fit_from)``.
- NumPy path is unchanged — identity lookup succeeds without the fallback there.
- Multi-pixelised-source case intentionally not fixed here; tracked by the
  ``galaxy_pytree_token.md`` follow-up prompt.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)