### PR TITLE
feat: register FitImaging, DatasetModel, Galaxies as pytrees in AnalysisImaging

### DIFF
--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -171,8 +171,12 @@ class AnalysisImaging(AnalysisDataset):
         else (``galaxies``, ``dataset_model`` and the autoarray wrappers they
         carry) is dynamic per fit.
         """
-        from autoarray.abstract_ndarray import register_instance_pytree
+        from autoarray.abstract_ndarray import (
+            _pytree_registered_classes,
+            register_instance_pytree,
+        )
         from autoarray.dataset.dataset_model import DatasetModel
+        from autoconf.jax_wrapper import register_pytree_node
         from autogalaxy.galaxy.galaxies import Galaxies
 
         register_instance_pytree(
@@ -180,7 +184,24 @@ class AnalysisImaging(AnalysisDataset):
             no_flatten=("dataset", "adapt_images", "settings"),
         )
         register_instance_pytree(DatasetModel)
-        register_instance_pytree(Galaxies)
+
+        # ``Galaxies`` is a ``list`` subclass — the generic ``__dict__`` flatten
+        # in ``register_instance_pytree`` would drop the list contents. Register
+        # a custom flatten that carries the list items as dynamic children.
+        if Galaxies not in _pytree_registered_classes:
+            def _flatten_galaxies(galaxies):
+                dict_items = tuple(sorted(galaxies.__dict__.items()))
+                return tuple(galaxies), dict_items
+
+            def _unflatten_galaxies(aux, children):
+                new = Galaxies.__new__(Galaxies)
+                list.__init__(new, children)
+                for key, value in aux:
+                    setattr(new, key, value)
+                return new
+
+            register_pytree_node(Galaxies, _flatten_galaxies, _unflatten_galaxies)
+            _pytree_registered_classes.add(Galaxies)
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """

--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -141,6 +141,9 @@ class AnalysisImaging(AnalysisDataset):
             The fit of the galaxies to the imaging dataset, which includes the log likelihood.
         """
 
+        if self._use_jax:
+            self._register_fit_imaging_pytrees()
+
         galaxies = self.galaxies_via_instance_from(
             instance=instance,
         )
@@ -157,6 +160,27 @@ class AnalysisImaging(AnalysisDataset):
             settings=self.settings,
             xp=self._xp,
         )
+
+    @staticmethod
+    def _register_fit_imaging_pytrees() -> None:
+        """Register every type reachable from a ``FitImaging`` return value
+        so ``jax.jit(fit_from)`` can flatten its output.
+
+        ``dataset``, ``adapt_images`` and ``settings`` are constants per
+        analysis — ride as aux so JAX does not recurse into them. Everything
+        else (``galaxies``, ``dataset_model`` and the autoarray wrappers they
+        carry) is dynamic per fit.
+        """
+        from autoarray.abstract_ndarray import register_instance_pytree
+        from autoarray.dataset.dataset_model import DatasetModel
+        from autogalaxy.galaxy.galaxies import Galaxies
+
+        register_instance_pytree(
+            FitImaging,
+            no_flatten=("dataset", "adapt_images", "settings"),
+        )
+        register_instance_pytree(DatasetModel)
+        register_instance_pytree(Galaxies)
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """

--- a/test_autogalaxy/imaging/model/test_analysis_imaging.py
+++ b/test_autogalaxy/imaging/model/test_analysis_imaging.py
@@ -37,3 +37,16 @@ def test__figure_of_merit__matches_correct_fit_given_galaxy_profiles(
     fit = ag.FitImaging(dataset=masked_imaging_7x7, galaxies=galaxies)
 
     assert fit.log_likelihood == fit_figure_of_merit
+
+
+def test__register_fit_imaging_pytrees__registers_fit_galaxies_and_dataset_model():
+    from autoarray.abstract_ndarray import _pytree_registered_classes
+    from autoarray.dataset.dataset_model import DatasetModel
+    from autogalaxy.galaxy.galaxies import Galaxies
+    from autogalaxy.imaging.fit_imaging import FitImaging
+
+    ag.AnalysisImaging._register_fit_imaging_pytrees()
+
+    assert FitImaging in _pytree_registered_classes
+    assert DatasetModel in _pytree_registered_classes
+    assert Galaxies in _pytree_registered_classes

--- a/test_autogalaxy/imaging/model/test_analysis_imaging.py
+++ b/test_autogalaxy/imaging/model/test_analysis_imaging.py
@@ -50,3 +50,5 @@ def test__register_fit_imaging_pytrees__registers_fit_galaxies_and_dataset_model
     assert FitImaging in _pytree_registered_classes
     assert DatasetModel in _pytree_registered_classes
     assert Galaxies in _pytree_registered_classes
+
+


### PR DESCRIPTION
## Summary

Register `FitImaging`, `DatasetModel`, and `Galaxies` as JAX pytrees in `AnalysisImaging.fit_from`, mirroring autolens's `_register_fit_imaging_pytrees` implementation. Unblocks `jax.jit(analysis.fit_from)(instance)` returning a `FitImaging` with `jax.Array` leaves on the autogalaxy imaging path. Required by autogalaxy_workspace_test's upcoming `jax_likelihood_functions/imaging/` scripts (PyAutoLabs/autogalaxy_workspace_test#8).

## API Changes

None — internal changes only. `_register_fit_imaging_pytrees` is a new private staticmethod on `AnalysisImaging`; `fit_from` now calls it when `use_jax=True` (no behaviour change on the NumPy path). See full details below.

## Test Plan

- [x] `test_autogalaxy/imaging/model/test_analysis_imaging.py` — new test asserts `FitImaging`, `DatasetModel`, `Galaxies` register into `_pytree_registered_classes`
- [x] `test_autogalaxy/imaging/` passes (69/69)
- [x] `test_autogalaxy/analysis/` passes (33/33)
- [ ] Integration: autogalaxy_workspace_test/scripts/jax_likelihood_functions/imaging/ scripts (follow-up PR)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `autogalaxy.imaging.model.analysis.AnalysisImaging._register_fit_imaging_pytrees()` (staticmethod, private) — registers `ag.FitImaging`, `aa.DatasetModel`, and `ag.Galaxies` with `autoarray.abstract_ndarray.register_instance_pytree`. `FitImaging` is registered with `no_flatten=("dataset", "adapt_images", "settings")` so per-fit constants ride as pytree aux data. `DatasetModel` registration is idempotent — it is already registered by `autolens.imaging.model.analysis.AnalysisImaging._register_fit_imaging_pytrees` in the autolens package; `register_instance_pytree` is guarded by `_pytree_registered_classes` and skips duplicate calls.

### Changed Behaviour

- `AnalysisImaging.fit_from(instance)` — now calls `self._register_fit_imaging_pytrees()` on entry when `self._use_jax` is True. No effect on the NumPy path (`use_jax=False`).

### Migration

None — no existing user-visible API is altered.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)