### PR TITLE
docs(weak-lensing): document shear API across LensCalc, Isothermal, ExternalShear

### DIFF
--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -519,33 +519,53 @@ class LensCalc:
         return convergence
 
     def shear_yx_2d_via_hessian_from(self, grid, xp=np) -> ShearYX2DIrregular:
-        """
-        Returns the 2D (y,x) shear vectors of the lensing object, which are computed from the 2D deflection angle map
-        via the Hessian using the expressions (see equation 57 https://inspirehep.net/literature/419263):
+        r"""
+        Returns the 2D weak-lensing shear vector field of the lensing object, computed from the deflection-angle
+        Hessian (see equation 57 of https://inspirehep.net/literature/419263):
 
-        `shear_y = hessian_{1,0} =  hessian_{0,1} = hessian_yx = hessian_xy`
-        `shear_x = 0.5 * (hessian_{0,0} - hessian_{1,1}) = 0.5 * (hessian_xx - hessian_yy)`
+        .. math::
 
-        By going via the Hessian, the shear vectors can be calculated at any (y,x) coordinate, therefore using either a
-        2D uniform or irregular grid.
+            \gamma_1 = \tfrac{1}{2} (\partial^2 \psi / \partial x^2 - \partial^2 \psi / \partial y^2)
+                     = 0.5 \, (H_{xx} - H_{yy})
 
-        This calculation of the shear vectors is independent of analytic calculations defined within `MassProfile`
-        objects and can therefore be used as a cross-check.
+            \gamma_2 = \partial^2 \psi / \partial x \partial y
+                     = H_{xy} = H_{yx}
 
-        The result is returned as a `ShearYX2D` dats structure, which has shape [total_shear_vectors, 2], where
-        entries for [:,0] are the gamma_2 values and entries for [:,1] are the gamma_1 values.
+        where :math:`\psi(\theta)` is the lensing potential and :math:`H_{ij}` are its second partial derivatives,
+        i.e. the components of the Hessian returned by ``hessian_from``.  The two components together encode the
+        full distortion tensor of a background source: :math:`\gamma_1` is the stretch along the x/y axes and
+        :math:`\gamma_2` is the stretch along the diagonals.
 
-        Note therefore that this convention means the FIRST entries in the array are the gamma_2 values and the SECOND
-        entries are the gamma_1 values.
+        Because the Hessian is computed numerically (Richardson-extrapolated finite differences in NumPy, or
+        ``jax.jacfwd`` in JAX), this routine works for **any** ``MassProfile``, ``Galaxy``, ``Galaxies`` or
+        ``Tracer`` that exposes ``deflections_yx_2d_from`` — no per-profile analytic formula is required.  It can
+        therefore be used as a numerical cross-check of analytic shear methods such as
+        ``Isothermal.shear_yx_2d_from`` (see ``test_isothermal.py``).  It also accepts both uniform ``Grid2D`` and
+        irregular ``Grid2DIrregular`` grids, which makes it the natural choice for simulating a weak-lensing
+        shear field on either a regular pixel grid or at the discrete positions of background source galaxies.
+
+        Convention
+        ----------
+        The result is returned as a ``ShearYX2DIrregular`` data structure of shape ``[total_shear_vectors, 2]``,
+        where:
+
+        - ``[:, 0]`` are the :math:`\gamma_2` values
+        - ``[:, 1]`` are the :math:`\gamma_1` values
+
+        Note therefore that the FIRST column is :math:`\gamma_2` and the SECOND column is :math:`\gamma_1`.  This
+        ordering matches the ``[y, x]`` ordering used elsewhere in the project for vector fields, since
+        :math:`\gamma_2` plays the role of the "y" component and :math:`\gamma_1` the "x" component when the shear
+        field is treated as a 2D pseudo-vector.
 
         Parameters
         ----------
-        grids
+        grid
             The 2D grid of (y,x) arc-second coordinates the deflection angles and Hessian are computed on.
         xp
-            The array module to use for the computation (e.g. `numpy` or `jax.numpy`). Passed through to
-            `hessian_from`. When `xp` is not `numpy` (e.g. inside a `jax.jit` trace) the result is returned
-            as a raw array of shape `(N, 2)` rather than a `ShearYX2DIrregular` wrapper.
+            The array module to use for the computation (e.g. ``numpy`` or ``jax.numpy``).  Passed through to
+            ``hessian_from``.  When ``xp`` is not ``numpy`` (e.g. inside a ``jax.jit`` trace) the result is
+            returned as a raw array of shape ``(N, 2)`` rather than a ``ShearYX2DIrregular`` wrapper, because
+            ``ShearYX2DIrregular`` is not a registered JAX pytree.
         """
 
         hessian_yy, hessian_xy, hessian_yx, hessian_xx = self.hessian_from(

--- a/autogalaxy/profiles/mass/sheets/external_shear.py
+++ b/autogalaxy/profiles/mass/sheets/external_shear.py
@@ -9,15 +9,36 @@ from autogalaxy import convert
 
 class ExternalShear(MassProfile):
     def __init__(self, gamma_1: float = 0.0, gamma_2: float = 0.0):
-        """
-        An `ExternalShear` term, to model the line-of-sight contribution of other galaxies / satellites.
+        r"""
+        Constant external shear term used in strong-lens mass models.
 
-        The shear angle is defined in the direction of stretching of the image. Therefore, if an object located \
-        outside the lens is responsible for the shear, it will be offset 90 degrees from the value of angle.
+        ``ExternalShear`` represents the line-of-sight contribution to the lensing potential from mass that is
+        not part of the primary lens — typically nearby group/cluster members, large-scale structure, or
+        unmodelled satellites.  Because this contribution is approximately uniform across the small angular
+        extent of a strong-lens system, it is parameterised as a constant shear with two components,
+        :math:`\gamma_1` and :math:`\gamma_2`, in the same convention as
+        ``LensCalc.shear_yx_2d_via_hessian_from`` and ``ShearYX2DIrregular``:
+
+        - :math:`\gamma_1` produces stretching along the x/y axes
+        - :math:`\gamma_2` produces stretching along the diagonals
+
+        The associated shear *magnitude* and *position angle* (degrees, anticlockwise from the +x axis) are:
+
+        .. math::
+
+            |\gamma| = \sqrt{\gamma_1^2 + \gamma_2^2}, \qquad
+            \phi = \tfrac{1}{2} \, \mathrm{arctan2}(\gamma_2, \gamma_1).
+
+        Note that the shear *position angle* lies in the direction of image stretching.  An external mass
+        located in the *direction of compression* therefore appears at an angle offset by 90 degrees from
+        :math:`\phi`.
 
         Parameters
         ----------
-        gamma
+        gamma_1
+            The :math:`\gamma_1` shear component.
+        gamma_2
+            The :math:`\gamma_2` shear component.
         """
 
         super().__init__(centre=(0.0, 0.0), ell_comps=(0.0, 0.0))
@@ -25,11 +46,14 @@ class ExternalShear(MassProfile):
         self.gamma_2 = gamma_2
 
     def magnitude(self, xp=np):
+        r"""Returns the shear magnitude :math:`|\gamma| = \sqrt{\gamma_1^2 + \gamma_2^2}`."""
         return convert.shear_magnitude_from(
             gamma_1=self.gamma_1, gamma_2=self.gamma_2, xp=xp
         )
 
     def angle(self, xp=np):
+        r"""Returns the shear position angle :math:`\phi = \tfrac{1}{2}\,\mathrm{arctan2}(\gamma_2, \gamma_1)`
+        in degrees, in the [0, 180) convention used elsewhere in the package."""
         return convert.shear_angle_from(
             gamma_1=self.gamma_1, gamma_2=self.gamma_2, xp=xp
         )
@@ -42,13 +66,25 @@ class ExternalShear(MassProfile):
 
     @aa.decorators.to_array
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
+        """A pure shear term has zero convergence at every grid point."""
         return xp.zeros(shape=grid.shape[0])
 
     @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
+        r"""
+        Returns the lensing potential of the constant external shear, given by:
+
+        .. math::
+
+            \psi(\theta) = -\tfrac{1}{2} |\gamma| \, r^2 \, \cos\!\big(2\,(\varphi - \phi_\gamma)\big)
+
+        where :math:`r, \varphi` are the polar coordinates of ``grid`` and :math:`\phi_\gamma` is the shear
+        position angle (offset by ``-90 deg`` to remain consistent with the deflection-angle convention used
+        elsewhere in PyAutoLens).
+        """
         shear_angle = (
             self.angle(xp) - 90
-        )  ##to be onsistent with autolens deflection angle calculation
+        )  # offset by -90 deg to match the deflection-angle convention used elsewhere
         phig = xp.deg2rad(shear_angle)
         shear_amp = self.magnitude(xp=xp)
         phicoord = xp.arctan2(grid.array[:, 0], grid.array[:, 1])
@@ -59,14 +95,28 @@ class ExternalShear(MassProfile):
     @aa.decorators.to_vector_yx
     @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        """
-        Calculate the deflection angles at a given set of arc-second gridded coordinates.
+        r"""
+        Returns the deflection angles of the constant external shear at each ``(y, x)`` arc-second
+        coordinate.
+
+        In the profile's rotated reference frame (where the shear position angle is aligned with the x-axis)
+        the deflection reduces to:
+
+        .. math::
+
+            \alpha_y(y, x) = -|\gamma| \, y, \qquad \alpha_x(y, x) = +|\gamma| \, x.
+
+        The ``@transform(rotate_back=True)`` decorator rotates the input grid into this aligned frame and
+        rotates the resulting deflection vectors back into the original frame.  Because the shear is a spin-2
+        field, the *position angle* :math:`\phi` of the shear is encoded in the rotation of the grid and not
+        as an extra factor in the deflection formula above.
 
         Parameters
         ----------
         grid
             The grid of (y,x) arc-second coordinates the deflection angles are computed on.
-
+        xp
+            The array module (``numpy`` or ``jax.numpy``).
         """
         deflection_y = -xp.multiply(self.magnitude(xp=xp), grid.array[:, 0])
         deflection_x = xp.multiply(self.magnitude(xp=xp), grid.array[:, 1])

--- a/autogalaxy/profiles/mass/total/isothermal.py
+++ b/autogalaxy/profiles/mass/total/isothermal.py
@@ -110,20 +110,45 @@ class Isothermal(PowerLaw):
     @aa.decorators.to_vector_yx
     @aa.decorators.transform
     def shear_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        """
-        Calculate the (gamma_y, gamma_x) shear vector field on a grid of (y,x) arc-second coordinates.
+        r"""
+        Returns the analytic 2D weak-lensing shear vector field :math:`(\gamma_2, \gamma_1)` of the elliptical
+        isothermal mass distribution on a grid of ``(y, x)`` arc-second coordinates.
 
-        The result is returned as a `ShearYX2D` dats structure, which has shape [total_shear_vectors, 2], where
-        entries for [:,0] are the gamma_2 values and entries for [:,1] are the gamma_1 values.
+        For an axis-aligned isothermal profile centred on the origin the shear components reduce to:
 
-        Note therefore that this convention means the FIRST entries in the array are the gamma_2 values and the SECOND
-        entries are the gamma_1 values.
+        .. math::
+
+            \gamma_1 = -\kappa(\theta) \, \frac{x^2 - y^2}{x^2 + y^2}
+
+            \gamma_2 = -2 \, \kappa(\theta) \, \frac{x \, y}{x^2 + y^2}
+
+        where :math:`\kappa(\theta)` is the convergence at the rotated grid coordinate.  After evaluation in the
+        profile's reference frame the shear vector field is rotated back into the original frame using the
+        ``2 * angle`` rotation appropriate for a spin-2 quantity (the shear transforms as a spin-2 field, so a
+        coordinate rotation by ``angle`` rotates the components by ``2 * angle``).
+
+        This analytic path is mathematically equivalent to ``LensCalc.shear_yx_2d_via_hessian_from``, which
+        derives the same shear from finite-difference (or JAX) derivatives of ``deflections_yx_2d_from``.  The
+        cross-check is exercised in
+        ``test_autogalaxy/profiles/mass/total/test_isothermal.py::test__shear_yx_2d_from__matches_via_hessian``.
+
+        Convention
+        ----------
+        The result is returned as a vector-field with shape ``[total_shear_vectors, 2]`` where:
+
+        - ``[:, 0]`` are the :math:`\gamma_2` values
+        - ``[:, 1]`` are the :math:`\gamma_1` values
+
+        i.e. the FIRST column is :math:`\gamma_2` and the SECOND column is :math:`\gamma_1`.  This ordering
+        matches the convention used by ``ShearYX2D`` / ``ShearYX2DIrregular`` and
+        ``LensCalc.shear_yx_2d_via_hessian_from``.
 
         Parameters
         ----------
         grid
-            The grid of (y,x) arc-second coordinates the deflection angles are computed on.
-
+            The grid of (y,x) arc-second coordinates the shear vectors are computed on.
+        xp
+            The array module (``numpy`` or ``jax.numpy``).
         """
 
         convergence = self.convergence_2d_from(grid=grid, xp=xp, **kwargs)

--- a/autogalaxy/util/shear_field.py
+++ b/autogalaxy/util/shear_field.py
@@ -1,25 +1,46 @@
 """
 Weak-lensing shear field data structures.
 
-This module extends **PyAutoArray**'s vector-field classes with properties specific to
-weak gravitational lensing.  A *shear field* is a set of (γ₂, γ₁) complex shear
-components stored on a 2D grid; each vector encodes the shape distortion induced on a
-background source galaxy by the intervening mass distribution.
+This module extends **PyAutoArray**'s vector-field classes with properties specific to weak gravitational
+lensing.  A *shear field* is a set of complex shear components :math:`(\\gamma_2, \\gamma_1)` stored on a 2D
+grid; each vector encodes the shape distortion induced on a background source galaxy by the intervening
+mass distribution.
+
+Where shear fields come from
+----------------------------
+The shear field of a strong lens model is produced by ``LensCalc.shear_yx_2d_via_hessian_from`` (in
+``autogalaxy/operate/lens_calc.py``) which derives the shear from the Hessian of the lensing potential.
+For analytic profiles such as ``Isothermal`` the shear is also available directly via
+``shear_yx_2d_from``; the two routines agree by construction (see the cross-check test in
+``test_autogalaxy/profiles/mass/total/test_isothermal.py``).
+
+For weak-lensing simulations the same Hessian-derived shear is the natural input to a simulator: evaluating
+``shear_yx_2d_via_hessian_from`` on the (y, x) positions of a population of background source galaxies
+produces the noise-free shear measurement at each source — a direct analogue of the deflection-angle field
+used for strong-lens simulators.
 
 Convention
 ----------
-The shear components are stored as ``[γ₂, γ₁]`` (``[:, 0]`` is γ₂, ``[:, 1]`` is γ₁),
-following the standard lensing sign convention where the position angle φ is measured
-counter-clockwise from the positive x-axis.
+The shear components are stored as ``[\\gamma_2, \\gamma_1]`` (``[:, 0]`` is :math:`\\gamma_2`, ``[:, 1]`` is
+:math:`\\gamma_1`):
+
+- :math:`\\gamma_1` produces stretching along the x/y axes
+- :math:`\\gamma_2` produces stretching along the diagonals
+
+The shear *position angle* :math:`\\phi = \\tfrac{1}{2} \\mathrm{arctan2}(\\gamma_2, \\gamma_1)` is measured
+counter-clockwise from the positive x-axis, matching the convention used by ``ExternalShear`` and the helpers
+in ``autogalaxy/convert.py``.  Storing :math:`\\gamma_2` first matches the ``[y, x]`` ordering used elsewhere
+in the project for vector fields, since :math:`\\gamma_2` plays the role of the "y" component and
+:math:`\\gamma_1` plays the role of the "x" component when shear is treated as a 2D pseudo-vector.
 
 Two concrete classes are provided:
 
-- ``ShearYX2D`` — regular grid variant (inherits ``aa.VectorYX2D``).
-- ``ShearYX2DIrregular`` — irregular grid variant (inherits ``aa.VectorYX2DIrregular``).
+- ``ShearYX2D`` — regular-grid variant (inherits ``aa.VectorYX2D``).
+- ``ShearYX2DIrregular`` — irregular-grid variant (inherits ``aa.VectorYX2DIrregular``).
 
-Both classes inherit the shared mixin ``AbstractShearField`` which provides derived
-quantities: ellipticities, semi-major/minor axes, position angles (``phis``), and
-``matplotlib`` ellipse patches for visualization.
+Both classes inherit the shared mixin ``AbstractShearField`` which provides derived quantities for
+visualisation and analysis: ``ellipticities``, ``semi_major_axes`` / ``semi_minor_axes``, position angles
+(``phis``), and ``matplotlib`` ellipse patches (``elliptical_patches``).
 """
 import logging
 import numpy as np
@@ -32,11 +53,19 @@ logger = logging.getLogger(__name__)
 
 
 class AbstractShearField:
+    """
+    Mixin providing weak-lensing-specific derived quantities for ``ShearYX2D`` / ``ShearYX2DIrregular``.
+
+    Treats the underlying ``[\\gamma_2, \\gamma_1]`` vector field as a set of weak-lensing shear
+    measurements and exposes the corresponding ellipticity, semi-axes, position angle, and
+    visualisation-ready ``matplotlib`` ellipse patches for each grid point.
+    """
+
     @property
     def ellipticities(self) -> aa.ArrayIrregular:
-        """
-        If we treat this vector field as a set of weak lensing shear measurements, the galaxy ellipticity each vector
-        corresponds too.
+        r"""
+        Returns the shear magnitude :math:`|\gamma| = \sqrt{\gamma_1^2 + \gamma_2^2}` at each grid point,
+        which in the weak-lensing limit equals the induced ellipticity of a background source galaxy.
         """
         return aa.ArrayIrregular(
             values=np.sqrt(self.slim[:, 0] ** 2 + self.slim[:, 1] ** 2.0)
@@ -45,24 +74,28 @@ class AbstractShearField:
     @property
     def semi_major_axes(self) -> aa.ArrayIrregular:
         """
-        If we treat this vector field as a set of weak lensing shear measurements, the semi-major axis of each
-        galaxy ellipticity that each vector corresponds too.
+        Returns the semi-major axis ``3 * (1 + |gamma|)`` of the ellipse representing each shear vector.
+
+        The factor of 3 is a fixed visual scale used so the rendered ellipses are large enough to be visible
+        on top of a typical lensing image.  This is a *visualisation* quantity, not a physical galaxy size.
         """
         return aa.ArrayIrregular(values=3 * (1 + self.ellipticities))
 
     @property
     def semi_minor_axes(self) -> aa.ArrayIrregular:
         """
-        If we treat this vector field as a set of weak lensing shear measurements, the semi-minor axis of each
-        galaxy ellipticity that each vector corresponds too.
+        Returns the semi-minor axis ``3 * (1 - |gamma|)`` of the ellipse representing each shear vector.
+
+        See ``semi_major_axes`` for the role of the ``3`` factor.
         """
         return aa.ArrayIrregular(values=3 * (1 - self.ellipticities))
 
     @property
     def phis(self) -> aa.ArrayIrregular:
-        """
-        If we treat this vector field as a set of weak lensing shear measurements, the position angle defined
-        counter clockwise from the positive x-axis of each galaxy ellipticity that each vector corresponds too.
+        r"""
+        Returns the shear position angle :math:`\phi = \tfrac{1}{2} \, \mathrm{arctan2}(\gamma_2, \gamma_1)`
+        in degrees, measured counter-clockwise from the positive x-axis.  This is the angle along which a
+        background source is *stretched* by the shear.
         """
         return aa.ArrayIrregular(
             values=np.arctan2(self.slim[:, 0], self.slim[:, 1]) * 180.0 / np.pi / 2.0
@@ -71,8 +104,9 @@ class AbstractShearField:
     @property
     def elliptical_patches(self) -> "typing.List[Ellipse]":
         """
-        If we treat this vector field as a set of weak lensing shear measurements, the elliptical patch representing
-        each galaxy ellipticity. This patch is used for visualizing an ellipse of each galaxy in an image.
+        Returns a list of ``matplotlib.patches.Ellipse`` objects, one per grid point, ready to be added to a
+        plotted image to visualise the shear field.  The width / height / angle of each patch are taken from
+        ``semi_major_axes``, ``semi_minor_axes`` and ``phis``.
         """
         from matplotlib.patches import Ellipse
 
@@ -91,53 +125,49 @@ class AbstractShearField:
 
 
 class ShearYX2D(aa.VectorYX2D, AbstractShearField):
-    """
-    A regular shear field, which is collection of (y,x) vectors which are located on a uniform grid
-    of (y,x) coordinates.
+    r"""
+    A weak-lensing shear field on a uniform (regular) grid of ``(y, x)`` coordinates.
 
-    The structure of this data structure is described in
-    `autoarray.structures.vectors.uniform.VectorYX2D`
+    The underlying storage is inherited from ``autoarray.structures.vectors.uniform.VectorYX2D``.  This
+    class adds the weak-lensing-specific properties defined on ``AbstractShearField`` (ellipticities,
+    semi-major / semi-minor axes, position angles, ``matplotlib`` ellipse patches).
 
-    This class extends `VectorYX2D` to include methods that are specific to a shear field, typically
-    used for weak lensing calculations.
-
-    This data structure is of shape [total_vectors, 2], where entries for [:,0] are the gamma_2 values and
-    entries for [:,1] are the gamma_1 values.
-
-    Note therefore that this convention means the FIRST entries in the array are the gamma_2 values and the SECOND
-    entries are the gamma_1 values.
+    Storage convention
+    ------------------
+    Shape: ``[total_vectors, 2]``.  Column 0 is :math:`\gamma_2` (cross / diagonal stretch), column 1 is
+    :math:`\gamma_1` (plus / axis-aligned stretch).  This matches the output of
+    ``LensCalc.shear_yx_2d_via_hessian_from`` and ``Isothermal.shear_yx_2d_from``.
 
     Parameters
     ----------
     vectors
-        The 2D (y,x) vectors on an irregular grid that represent the vector-field.
+        The 2D ``[\gamma_2, \gamma_1]`` shear components on a uniform grid.
     grid
-        The irregular grid of (y,x) coordinates where each vector is located.
+        The uniform grid of ``(y, x)`` coordinates where each shear vector is located.
     """
 
 
 class ShearYX2DIrregular(aa.VectorYX2DIrregular, AbstractShearField):
-    """
-    An irregular shear field, which is collection of (y,x) vectors which are located on an irregular grid
-    of (y,x) coordinates.
+    r"""
+    A weak-lensing shear field on an irregular grid of ``(y, x)`` coordinates.
 
-    The structure of this data structure is described in
-    `autoarray.structures.vectors.irregular.VectorYX2DIrregular`
+    The irregular variant is the natural data structure for shear measurements at the discrete positions of
+    a population of background source galaxies.  The underlying storage is inherited from
+    ``autoarray.structures.vectors.irregular.VectorYX2DIrregular``.  This class adds the
+    weak-lensing-specific properties defined on ``AbstractShearField``.
 
-    This class extends `VectorYX2DIrregular` to include methods that are specific to a shear field, typically
-    used for weak lensing calculations.
+    ``LensCalc.shear_yx_2d_via_hessian_from`` returns ``ShearYX2DIrregular`` on the NumPy path; on the JAX
+    path it returns a raw ``(N, 2)`` array (because ``ShearYX2DIrregular`` is not a registered JAX pytree).
 
-
-    This data structure is of shape [total_vectors, 2], where entries for [:,0] are the gamma_2 values and
-    entries for [:,1] are the gamma_1 values.
-
-    Note therefore that this convention means the FIRST entries in the array are the gamma_2 values and the SECOND
-    entries are the gamma_1 values.
+    Storage convention
+    ------------------
+    Shape: ``[total_vectors, 2]``.  Column 0 is :math:`\gamma_2` (cross / diagonal stretch), column 1 is
+    :math:`\gamma_1` (plus / axis-aligned stretch).
 
     Parameters
     ----------
     vectors
-        The 2D (y,x) vectors on an irregular grid that represent the vector-field.
+        The 2D ``[\gamma_2, \gamma_1]`` shear components on an irregular grid.
     grid
-        The irregular grid of (y,x) coordinates where each vector is located.
+        The irregular grid of ``(y, x)`` coordinates where each shear vector is located.
     """

--- a/test_autogalaxy/profiles/mass/total/test_isothermal.py
+++ b/test_autogalaxy/profiles/mass/total/test_isothermal.py
@@ -1,6 +1,9 @@
+import numpy as np
 import pytest
 
 import autogalaxy as ag
+
+from autogalaxy.operate.lens_calc import LensCalc
 
 grid = ag.Grid2DIrregular([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [2.0, 4.0]])
 
@@ -175,3 +178,28 @@ def test__shear_yx_2d_from__isothermal_with_ell_comps():
 
     assert shear[0, 0] == pytest.approx(0.0, abs=1e-4)
     assert shear[0, 1] == pytest.approx(-1.11803398874, 1e-4)
+
+
+def test__shear_yx_2d_from__matches_via_hessian():
+    """
+    The analytic ``Isothermal.shear_yx_2d_from`` and the numerical
+    ``LensCalc.shear_yx_2d_via_hessian_from`` must agree to within finite-difference accuracy at every grid
+    point: both compute the same physical shear in the same ``[gamma_2, gamma_1]`` convention, the former
+    via a closed-form formula and the latter via Richardson-extrapolated derivatives of
+    ``deflections_yx_2d_from``.
+
+    This cross-check guards against either path silently drifting (e.g. a sign flip, a column swap, or a
+    rotation-frame mistake) and pins the convention that downstream weak-lensing code relies on.
+    """
+    grid = ag.Grid2DIrregular(values=[(0.7, 0.5), (1.0, 1.0), (-0.3, 0.6), (1.5, -0.4)])
+
+    mp = ag.mp.Isothermal(
+        centre=(0.0, 0.0), ell_comps=(0.1, -0.1), einstein_radius=2.0
+    )
+
+    shear_analytic = mp.shear_yx_2d_from(grid=grid)
+    shear_via_hessian = LensCalc.from_mass_obj(mp).shear_yx_2d_via_hessian_from(grid=grid)
+
+    np.testing.assert_allclose(
+        np.asarray(shear_analytic), np.asarray(shear_via_hessian), rtol=1e-3, atol=1e-6
+    )


### PR DESCRIPTION
## Summary

First step in adding weak gravitational lens analysis to PyAutoLens (issue #365). Audits and documents the existing shear infrastructure in PyAutoGalaxy so downstream weak-lensing work has a single, pinned convention to build on. Adds a cross-check unit test asserting the analytic and Hessian-derived shear paths agree.

## API Changes

None — internal documentation changes plus a new unit test. No public symbol added, removed, renamed, or behaviourally changed. The `[gamma_2, gamma_1]` storage convention used by `LensCalc.shear_yx_2d_via_hessian_from`, `Isothermal.shear_yx_2d_from`, `ExternalShear`, and `ShearYX2D` / `ShearYX2DIrregular` was already in place — this PR makes it explicit in docstrings and locks it in with a test.

See full details below.

## Test Plan

- [ ] `python -m pytest test_autogalaxy/profiles/mass/total/test_isothermal.py -x` — including the new `test__shear_yx_2d_from__matches_via_hessian` cross-check.
- [ ] `python -m pytest test_autogalaxy/operate/test_deflections.py -x` — confirm Hessian / shear paths still pass after docstring edits.
- [ ] `python -m pytest test_autogalaxy/profiles/mass/sheets/ -x` — confirm `ExternalShear` tests still pass.
- [ ] **(author note)** the new test was written but not executed in the development sandbox (no numpy installed there). Please run it locally before merging.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- `test_autogalaxy/profiles/mass/total/test_isothermal.py::test__shear_yx_2d_from__matches_via_hessian` — asserts `Isothermal.shear_yx_2d_from` agrees with `LensCalc.shear_yx_2d_via_hessian_from` to `rtol=1e-3, atol=1e-6` at four irregular grid points.

### Renamed
- None.

### Changed Signature
- None.

### Changed Behaviour
- None.

### Documentation
- `autogalaxy/operate/lens_calc.py::LensCalc.shear_yx_2d_via_hessian_from` — rewritten docstring with formal gamma_1 / gamma_2 definitions, `[gamma_2, gamma_1]` storage convention, NumPy vs JAX return types, and pointers to weak-lensing simulator usage.
- `autogalaxy/profiles/mass/total/isothermal.py::Isothermal.shear_yx_2d_from` — closed-form gamma_1 / gamma_2 formulas, `2 * angle` spin-2 rotation explanation, pointer to the new cross-check test.
- `autogalaxy/profiles/mass/sheets/external_shear.py::ExternalShear` — full class + method docstrings (`__init__`, `magnitude`, `angle`, `convergence_2d_from`, `potential_2d_from`, `deflections_yx_2d_from`).
- `autogalaxy/util/shear_field.py` — module docstring (sources of shear fields, downstream consumers, sign convention) plus class/property docstrings on `AbstractShearField`, `ShearYX2D`, `ShearYX2DIrregular`.

### Migration
- None — no caller-visible changes.

</details>

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EBbSyFVNAcoqxWWrwUB8Mz)_