### PR TITLE
fix: forward **kwargs through AnalysisImaging.__init__

### DIFF
--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -39,6 +39,7 @@ class AnalysisImaging(AnalysisDataset):
         settings: aa.Settings = None,
         title_prefix: str = None,
         use_jax: bool = True,
+        **kwargs,
     ):
         """
         Fits a galaxy model to an imaging dataset via a non-linear search.
@@ -77,6 +78,7 @@ class AnalysisImaging(AnalysisDataset):
             settings=settings,
             title_prefix=title_prefix,
             use_jax=use_jax,
+            **kwargs,
         )
 
     @property


### PR DESCRIPTION
## Summary

`ag.AnalysisImaging.__init__` previously had a custom signature that did NOT accept or forward `**kwargs`, silently dropping any extra keyword arguments passed by callers. This diverged from `al.AnalysisImaging`, which has no custom `__init__` and inherits `AnalysisDataset.__init__(..., **kwargs)` directly — so kwargs like `use_jax_for_visualization` flow through to `af.Analysis` cleanly on the autolens side but raise `TypeError` on the autogalaxy side.

This change adds `**kwargs` to the signature and forwards them to `super().__init__()`, restoring parity with autolens.

## API Changes

`ag.AnalysisImaging.__init__` now accepts arbitrary additional keyword arguments and forwards them through `AnalysisDataset.__init__` → `Analysis.__init__` → `af.Analysis.__init__`. No existing call sites are broken — this is a strict superset of the previous signature.

See full details below.

## Test Plan

- [x] Existing `test_autogalaxy/` suite passes (no behaviour changes, only signature relaxation). One pre-existing flaky test (`test_autogalaxy/profiles/light/test_snr.py::test__signal_to_noise_via_simulator__no_psf__snr_within_expected_range`) is deselected — confirmed failing on `origin/main` without this change.
- [x] Smoke-tested via `autogalaxy_workspace_test/scripts/imaging/visualization_jax.py` and `modeling_visualization_jit.py`, which now construct `AnalysisImaging(dataset=..., use_jax=True, use_jax_for_visualization=True)` without `TypeError`.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Signature
- `ag.AnalysisImaging.__init__(dataset, adapt_images=None, cosmology=None, settings=None, title_prefix=None, use_jax=True)` — now also accepts `**kwargs`, forwarded to `super().__init__()`. Previously, any unrecognised kwarg raised `TypeError: __init__() got an unexpected keyword argument`. After: extra kwargs flow through to `af.Analysis.__init__` (e.g. `use_jax_for_visualization`).

### Migration
- No migration needed for existing callers. New callers can now pass `use_jax_for_visualization=True` and other base-class kwargs directly:

  ```python
  # before this PR — raised TypeError
  ag.AnalysisImaging(dataset=dataset, use_jax=True, use_jax_for_visualization=True)

  # after this PR — works, mirrors al.AnalysisImaging
  ag.AnalysisImaging(dataset=dataset, use_jax=True, use_jax_for_visualization=True)
  ```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)