### PR TITLE
feat: check workspace version on import

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -120,6 +120,10 @@ from autoconf.fitsable import hdu_list_for_output_from
 
 __version__ = "2026.4.13.6"
 
+from autoconf import check_version
+
+check_version(__version__)
+
 
 def __getattr__(name):
     if name == "plot":


### PR DESCRIPTION
## Summary
Add a `check_version(__version__)` call to `autogalaxy/__init__.py` so workspace/library version mismatches surface on every script run, not just `welcome.py`. Pairs with the upstream PyAutoConf change (PyAutoLabs/PyAutoConf#100) which extends `check_version` to read from `config/general.yaml` and adds a YAML-driven bypass for `main`-branch users.

## API Changes
None to autogalaxy's public API. Importing `autogalaxy` now triggers a workspace-version check via `autoconf.workspace.check_version`, which may emit a warning (no version source found) or raise `autoconf.workspace.WorkspaceVersionMismatchError` (workspace and library versions disagree). Users on `main`-branch clones who hit this should disable via `version.workspace_version_check: False` in `config/general.yaml` — see PyAutoLabs/PyAutoConf#100 for the full rationale.

See full details below.

## Test Plan
- [ ] `pytest test_autogalaxy/` stays green
- [ ] `python -c "import autogalaxy"` from `autogalaxy_workspace/` succeeds silently
- [ ] `python -c "import autogalaxy"` from `/tmp` warns with the new message text

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `import autogalaxy` now calls `autoconf.workspace.check_version(autogalaxy.__version__)` at the end of `autogalaxy/__init__.py`. May warn (no `version.workspace_version` in config and no `version.txt`) or raise `autoconf.workspace.WorkspaceVersionMismatchError` (versions disagree).

### Migration
- Users on `main`-branch workspace clones should add to `config/general.yaml`:
  ```yaml
  version:
    workspace_version_check: False
  ```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)