### PR TITLE
refactor: replace os.path with pathlib

### DIFF
--- a/autogalaxy/analysis/chaining_util.py
+++ b/autogalaxy/analysis/chaining_util.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
-from os import path
+from pathlib import Path
 
 from autoconf import conf
 from autoconf.dictable import from_json, output_to_json
@@ -267,11 +267,11 @@ def lp_chain_tracer_from(light_result, settings_search):
     else:
         unique_tag = ""
 
-    lp_chain_tracer_path = path.join(
-        conf.instance.output_path,
-        settings_search.path_prefix,
-        unique_tag,
-        "light_dark_lp_chain_tracer.json",
+    lp_chain_tracer_path = (
+        Path(conf.instance.output_path)
+        / settings_search.path_prefix
+        / unique_tag
+        / "light_dark_lp_chain_tracer.json"
     )
 
     try:

--- a/autogalaxy/plot/plot_utils.py
+++ b/autogalaxy/plot/plot_utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 import numpy as np
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ def _save_subplot(fig, output_path, output_filename, output_format=None,
         plt.show()
     else:
         os.makedirs(str(output_path), exist_ok=True)
-        fpath = os.path.join(str(output_path), f"{output_filename}.{fmt}")
+        fpath = Path(output_path) / f"{output_filename}.{fmt}"
         fig.savefig(fpath, dpi=dpi, bbox_inches="tight", pad_inches=0.1)
     plt.close(fig)
 

--- a/autogalaxy/util/plot_utils.py
+++ b/autogalaxy/util/plot_utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 import numpy as np
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ def _save_subplot(fig, output_path, output_filename, output_format=None,
         plt.show()
     else:
         os.makedirs(str(output_path), exist_ok=True)
-        fpath = os.path.join(str(output_path), f"{output_filename}.{fmt}")
+        fpath = Path(output_path) / f"{output_filename}.{fmt}"
         fig.savefig(fpath, dpi=dpi, bbox_inches="tight", pad_inches=0.1)
     plt.close(fig)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,13 +10,13 @@ import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# documentation root, use Path(...).resolve() to make it absolute, like shown here.
 #
 
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, str(Path(".").resolve()))
 
 import autogalaxy
 

--- a/test_autogalaxy/analysis/analysis/test_analysis.py
+++ b/test_autogalaxy/analysis/analysis/test_analysis.py
@@ -1,12 +1,12 @@
 import os
-from os import path
+from pathlib import Path
 
 from autoconf.dictable import from_json
 
 import autofit as af
 import autogalaxy as ag
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__galaxies_via_instance(masked_imaging_7x7):

--- a/test_autogalaxy/analysis/analysis/test_analysis_dataset.py
+++ b/test_autogalaxy/analysis/analysis/test_analysis_dataset.py
@@ -1,11 +1,11 @@
 import pytest
 import numpy as np
-from os import path
 
 import autofit as af
 import autogalaxy as ag
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__instance_with_associated_adapt_images_from__galaxy_name_image_dict(

--- a/test_autogalaxy/analysis/test_plotter.py
+++ b/test_autogalaxy/analysis/test_plotter.py
@@ -1,23 +1,23 @@
 import csv
 import shutil
 import numpy as np
-from os import path
+from pathlib import Path
 import pytest
 
 import autogalaxy as ag
 
 from autogalaxy.analysis.plotter import Plotter
 
-directory = path.dirname(path.abspath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_plotter_setup():
-    return path.join("{}".format(directory), "files")
+    return directory / "files"
 
 
 def test__galaxies(masked_imaging_7x7, galaxies_7x7, plot_path, plot_patch):
-    if path.exists(plot_path):
+    if plot_path.exists():
         shutil.rmtree(plot_path)
 
     plotter = Plotter(image_path=plot_path)
@@ -27,11 +27,11 @@ def test__galaxies(masked_imaging_7x7, galaxies_7x7, plot_path, plot_patch):
         grid=masked_imaging_7x7.grids.lp,
     )
 
-    assert path.join(plot_path, "galaxies.png") in plot_patch.paths
-    assert path.join(plot_path, "galaxy_images.png") in plot_patch.paths
+    assert str(plot_path / "galaxies.png") in plot_patch.paths
+    assert str(plot_path / "galaxy_images.png") in plot_patch.paths
 
     image = ag.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "galaxy_images.fits"), hdu=1
+        file_path=plot_path / "galaxy_images.fits", hdu=1
     )
 
     assert image.shape == (5, 5)
@@ -42,7 +42,7 @@ def test__inversion(
     plot_path,
     plot_patch,
 ):
-    if path.exists(plot_path):
+    if plot_path.exists():
         shutil.rmtree(plot_path)
 
     plotter = Plotter(image_path=plot_path)
@@ -51,10 +51,10 @@ def test__inversion(
         inversion=rectangular_inversion_7x7_3x3,
     )
 
-    assert path.join(plot_path, "inversion_0_0.png") in plot_patch.paths
+    assert str(plot_path / "inversion_0_0.png") in plot_patch.paths
 
     with open(
-        path.join(plot_path, "source_plane_reconstruction_0.csv"), mode="r"
+        plot_path / "source_plane_reconstruction_0.csv", mode="r"
     ) as file:
         reader = csv.reader(file)
         header_list = next(reader)  # ['y', 'x', 'reconstruction', 'noise_map']
@@ -90,12 +90,10 @@ def test__adapt_images(
         adapt_images=adapt_images,
     )
 
-    plot_path = path.join(plot_path)
-
-    assert path.join(plot_path, "adapt_images.png") in plot_patch.paths
+    assert str(plot_path / "adapt_images.png") in plot_patch.paths
 
     image = ag.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "adapt_images.fits"), hdu=1
+        file_path=plot_path / "adapt_images.fits", hdu=1
     )
 
     assert image.shape == (5, 5)

--- a/test_autogalaxy/conftest.py
+++ b/test_autogalaxy/conftest.py
@@ -1,6 +1,6 @@
 
 import os
-from os import path
+from pathlib import Path
 import pytest
 from matplotlib import pyplot
 from unittest.mock import MagicMock
@@ -20,7 +20,7 @@ class PlotPatch:
         self.paths = []
 
     def __call__(self, path, *args, **kwargs):
-        self.paths.append(path)
+        self.paths.append(str(path))
 
 
 @pytest.fixture(name="plot_patch")
@@ -35,14 +35,14 @@ def make_plot_patch(monkeypatch):
     return plot_patch
 
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(autouse=True)
 def set_config_path(request):
     conf.instance.push(
-        new_path=path.join(directory, "config"),
-        output_path=path.join(directory, "output"),
+        new_path=directory / "config",
+        output_path=directory / "output",
     )
 
 
@@ -52,7 +52,7 @@ def remove_logs():
     for d, _, files in os.walk(directory):
         for file in files:
             if file.endswith(".log"):
-                os.remove(path.join(d, file))
+                os.remove(Path(d) / file)
 
 
 ### Datasets ###

--- a/test_autogalaxy/ellipse/model/test_analysis_ellipse.py
+++ b/test_autogalaxy/ellipse/model/test_analysis_ellipse.py
@@ -1,11 +1,11 @@
-from os import path
+from pathlib import Path
 
 import autofit as af
 import autogalaxy as ag
 
 from autogalaxy.ellipse.model.result import ResultEllipse
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__make_result__result_imaging_is_returned(masked_imaging_7x7):

--- a/test_autogalaxy/galaxy/plot/test_adapt_plotters.py
+++ b/test_autogalaxy/galaxy/plot/test_adapt_plotters.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 
 import autogalaxy.plot as aplt
 import pytest
@@ -6,12 +6,7 @@ import pytest
 
 @pytest.fixture(name="plot_path")
 def make_adapt_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "adapt",
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "adapt"
 
 
 def test__plot_adapt_adapt_images(
@@ -22,4 +17,4 @@ def test__plot_adapt_adapt_images(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "adapt_images.png") in plot_patch.paths
+    assert str(plot_path / "adapt_images.png") in plot_patch.paths

--- a/test_autogalaxy/galaxy/plot/test_galaxies_plotter.py
+++ b/test_autogalaxy/galaxy/plot/test_galaxies_plotter.py
@@ -1,16 +1,14 @@
-from os import path
+from pathlib import Path
 
 import autogalaxy.plot as aplt
 import pytest
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "galaxies"
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "galaxies"
 
 
 def test__galaxies_sub_plot_output(galaxies_x2_7x7, grid_2d_7x7, plot_path, plot_patch):
@@ -20,7 +18,7 @@ def test__galaxies_sub_plot_output(galaxies_x2_7x7, grid_2d_7x7, plot_path, plot
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "galaxies.png") in plot_patch.paths
+    assert str(plot_path / "galaxies.png") in plot_patch.paths
 
     aplt.subplot_galaxy_images(
         galaxies=galaxies_x2_7x7,
@@ -28,4 +26,4 @@ def test__galaxies_sub_plot_output(galaxies_x2_7x7, grid_2d_7x7, plot_path, plot
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "galaxy_images.png") in plot_patch.paths
+    assert str(plot_path / "galaxy_images.png") in plot_patch.paths

--- a/test_autogalaxy/galaxy/plot/test_galaxy_plotters.py
+++ b/test_autogalaxy/galaxy/plot/test_galaxy_plotters.py
@@ -1,16 +1,14 @@
-from os import path
+from pathlib import Path
 
 import autogalaxy.plot as aplt
 import pytest
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_galaxy_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "galaxy"
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "galaxy"
 
 
 def test__subplots_galaxy_quantities__all_are_output(
@@ -26,7 +24,7 @@ def test__subplots_galaxy_quantities__all_are_output(
         output_format="png",
     )
 
-    assert path.join(plot_path, "image.png") in plot_patch.paths
+    assert str(plot_path / "image.png") in plot_patch.paths
 
     aplt.subplot_galaxy_mass_profiles(
         galaxy=gal_x1_lp_x1_mp,
@@ -39,7 +37,7 @@ def test__subplots_galaxy_quantities__all_are_output(
         output_format="png",
     )
 
-    assert path.join(plot_path, "convergence.png") in plot_patch.paths
-    assert path.join(plot_path, "potential.png") in plot_patch.paths
-    assert path.join(plot_path, "deflections_y.png") in plot_patch.paths
-    assert path.join(plot_path, "deflections_x.png") in plot_patch.paths
+    assert str(plot_path / "convergence.png") in plot_patch.paths
+    assert str(plot_path / "potential.png") in plot_patch.paths
+    assert str(plot_path / "deflections_y.png") in plot_patch.paths
+    assert str(plot_path / "deflections_x.png") in plot_patch.paths

--- a/test_autogalaxy/galaxy/test_galaxy.py
+++ b/test_autogalaxy/galaxy/test_galaxy.py
@@ -1,5 +1,5 @@
 import numpy as np
-from os import path
+from pathlib import Path
 import pytest
 
 from autoconf.dictable import from_json, output_to_json
@@ -734,9 +734,7 @@ def test__decorator__oversample_uniform__profile_offset_from_centre__correct_num
 
 
 def test__output_to_and_load_from_json():
-    json_file = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "galaxy.json"
-    )
+    json_file = Path(__file__).resolve().parent / "files" / "galaxy.json"
 
     g0 = ag.Galaxy(
         redshift=1.0,

--- a/test_autogalaxy/imaging/model/test_analysis_imaging.py
+++ b/test_autogalaxy/imaging/model/test_analysis_imaging.py
@@ -1,11 +1,11 @@
-from os import path
+from pathlib import Path
 
 import autofit as af
 import autogalaxy as ag
 
 from autogalaxy.imaging.model.result import ResultImaging
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__make_result__result_imaging_is_returned(masked_imaging_7x7):

--- a/test_autogalaxy/imaging/model/test_plotter_imaging.py
+++ b/test_autogalaxy/imaging/model/test_plotter_imaging.py
@@ -1,44 +1,44 @@
 import shutil
-from os import path
 import pytest
 
 import autogalaxy as ag
 from autogalaxy.imaging.model.plotter import PlotterImaging
+from pathlib import Path
 
-directory = path.dirname(path.abspath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_plotter_setup():
-    return path.join("{}".format(directory), "files")
+    return directory / "files"
 
 
 def test__imaging(imaging_7x7, plot_path, plot_patch):
-    if path.exists(plot_path):
+    if Path(plot_path).exists():
         shutil.rmtree(plot_path)
 
     plotter = PlotterImaging(image_path=plot_path)
 
     plotter.imaging(dataset=imaging_7x7)
 
-    assert path.join(plot_path, "dataset.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dataset.png") in plot_patch.paths
 
     image = ag.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "dataset.fits"), hdu=1
+        file_path=Path(plot_path) / "dataset.fits", hdu=1
     )
 
     assert image.shape == (7, 7)
 
 
 def test__imaging_combined(imaging_7x7, plot_path, plot_patch):
-    if path.exists(plot_path):
+    if Path(plot_path).exists():
         shutil.rmtree(plot_path)
 
     visualizer = PlotterImaging(image_path=plot_path)
 
     visualizer.imaging_combined(dataset_list=[imaging_7x7, imaging_7x7])
 
-    assert path.join(plot_path, "dataset_combined.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dataset_combined.png") in plot_patch.paths
 
 
 def test__fit_imaging(
@@ -47,7 +47,7 @@ def test__fit_imaging(
     plot_path,
     plot_patch,
 ):
-    if path.exists(plot_path):
+    if Path(plot_path).exists():
         shutil.rmtree(plot_path)
 
     plotter = PlotterImaging(image_path=plot_path)
@@ -56,14 +56,14 @@ def test__fit_imaging(
         fit=fit_imaging_x2_galaxy_inversion_7x7,
     )
 
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(Path(plot_path) / "fit.png") in plot_patch.paths
 
-    image = ag.ndarray_via_fits_from(file_path=path.join(plot_path, "fit.fits"), hdu=1)
+    image = ag.ndarray_via_fits_from(file_path=Path(plot_path) / "fit.fits", hdu=1)
 
     assert image.shape == (5, 5)
 
     image = ag.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "model_galaxy_images.fits"), hdu=1
+        file_path=Path(plot_path) / "model_galaxy_images.fits", hdu=1
     )
 
     assert image.shape == (5, 5)
@@ -72,11 +72,11 @@ def test__fit_imaging(
 def test__fit_imaging_combined(
     fit_imaging_x2_galaxy_inversion_7x7, plot_path, plot_patch
 ):
-    if path.exists(plot_path):
+    if Path(plot_path).exists():
         shutil.rmtree(plot_path)
 
     visualizer = PlotterImaging(image_path=plot_path)
 
     visualizer.fit_imaging_combined(fit_list=2 * [fit_imaging_x2_galaxy_inversion_7x7])
 
-    assert path.join(plot_path, "fit_combined.png") in plot_patch.paths
+    assert str(Path(plot_path) / "fit_combined.png") in plot_patch.paths

--- a/test_autogalaxy/imaging/plot/test_fit_imaging_plotters.py
+++ b/test_autogalaxy/imaging/plot/test_fit_imaging_plotters.py
@@ -1,17 +1,15 @@
-from os import path
 
 import pytest
 
 import autogalaxy.plot as aplt
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_fit_imaging_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "fit"
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "plots" / "fit"
 
 
 def test__subplot_of_galaxy(fit_imaging_x2_galaxy_7x7, plot_path, plot_patch):
@@ -27,8 +25,8 @@ def test__subplot_of_galaxy(fit_imaging_x2_galaxy_7x7, plot_path, plot_patch):
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "of_galaxy_0.png") in plot_patch.paths
-    assert path.join(plot_path, "of_galaxy_1.png") in plot_patch.paths
+    assert str(Path(plot_path) / "of_galaxy_0.png") in plot_patch.paths
+    assert str(Path(plot_path) / "of_galaxy_1.png") in plot_patch.paths
 
     plot_patch.paths = []
 
@@ -39,5 +37,5 @@ def test__subplot_of_galaxy(fit_imaging_x2_galaxy_7x7, plot_path, plot_patch):
         output_format="png",
     )
 
-    assert path.join(plot_path, "of_galaxy_0.png") in plot_patch.paths
-    assert path.join(plot_path, "of_galaxy_1.png") not in plot_patch.paths
+    assert str(Path(plot_path) / "of_galaxy_0.png") in plot_patch.paths
+    assert str(Path(plot_path) / "of_galaxy_1.png") not in plot_patch.paths

--- a/test_autogalaxy/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autogalaxy/imaging/test_simulate_and_fit_imaging.py
@@ -1,11 +1,11 @@
 import os
-from os import path
 import shutil
 
 import numpy as np
 import pytest
 
 import autogalaxy as ag
+from pathlib import Path
 
 
 def test__perfect_fit__simulate_and_reload__chi_squared_zero():
@@ -35,34 +35,30 @@ def test__perfect_fit__simulate_and_reload__chi_squared_zero():
         shape_native=dataset.data.shape_native, pixel_scales=0.2
     )
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "data_temp",
-        "simulate_and_fit",
-    )
+    file_path = Path(Path(__file__).resolve().parent) / "data_temp" / "simulate_and_fit"
 
     try:
         shutil.rmtree(file_path)
     except FileNotFoundError:
         pass
 
-    if path.exists(file_path) is False:
+    if Path(file_path).exists() is False:
         os.makedirs(file_path)
 
     from autoarray.dataset.plot.imaging_plots import fits_imaging
 
     fits_imaging(
         dataset=dataset,
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        psf_path=path.join(file_path, "psf.fits"),
+        data_path=Path(file_path) / "data.fits",
+        noise_map_path=Path(file_path) / "noise_map.fits",
+        psf_path=Path(file_path) / "psf.fits",
         overwrite=True,
     )
 
     dataset = ag.Imaging.from_fits(
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        psf_path=path.join(file_path, "psf.fits"),
+        data_path=Path(file_path) / "data.fits",
+        noise_map_path=Path(file_path) / "noise_map.fits",
+        psf_path=Path(file_path) / "psf.fits",
         pixel_scales=0.2,
         over_sample_size_lp=1,
     )
@@ -79,11 +75,9 @@ def test__perfect_fit__simulate_and_reload__chi_squared_zero():
 
     assert fit.chi_squared == pytest.approx(0.0, 1e-4)
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "data_temp"
-    )
+    file_path = Path(Path(__file__).resolve().parent) / "data_temp"
 
-    if path.exists(file_path) is True:
+    if Path(file_path).exists() is True:
         shutil.rmtree(file_path)
 
 

--- a/test_autogalaxy/imaging/test_simulator.py
+++ b/test_autogalaxy/imaging/test_simulator.py
@@ -1,6 +1,6 @@
 import numpy as np
 import os
-from os import path
+from pathlib import Path
 import pytest
 import shutil
 

--- a/test_autogalaxy/interferometer/model/test_analysis_interferometer.py
+++ b/test_autogalaxy/interferometer/model/test_analysis_interferometer.py
@@ -1,12 +1,12 @@
-from os import path
 
 import autofit as af
 import autogalaxy as ag
 
 from autogalaxy.interferometer.model.result import ResultInterferometer
+from pathlib import Path
 
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__make_result__result_interferometer_is_returned(interferometer_7):

--- a/test_autogalaxy/interferometer/model/test_plotter_interferometer.py
+++ b/test_autogalaxy/interferometer/model/test_plotter_interferometer.py
@@ -1,5 +1,5 @@
-from os import path
 import pytest
+from pathlib import Path
 
 import autogalaxy as ag
 
@@ -7,12 +7,12 @@ from autogalaxy.interferometer.model.plotter import (
     PlotterInterferometer,
 )
 
-directory = path.dirname(path.abspath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_plotter_setup():
-    return path.join("{}".format(directory), "files")
+    return directory / "files"
 
 
 def test__interferometer(interferometer_7, plot_path, plot_patch):
@@ -20,10 +20,10 @@ def test__interferometer(interferometer_7, plot_path, plot_patch):
 
     plotter.interferometer(dataset=interferometer_7)
 
-    assert path.join(plot_path, "dataset.png") in plot_patch.paths
+    assert str(Path(plot_path) / "dataset.png") in plot_patch.paths
 
     image = ag.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "dataset.fits"), hdu=1
+        file_path=Path(plot_path) / "dataset.fits", hdu=1
     )
 
     assert image.shape == (7, 2)
@@ -41,16 +41,16 @@ def test__fit_interferometer(
         fit=fit_interferometer_x2_galaxy_inversion_7x7,
     )
 
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(Path(plot_path) / "fit.png") in plot_patch.paths
 
     image = ag.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "galaxy_images.fits"), hdu=1
+        file_path=Path(plot_path) / "galaxy_images.fits", hdu=1
     )
 
     assert image.shape == (5, 5)
 
     image = ag.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "fit_dirty_images.fits"), hdu=1
+        file_path=Path(plot_path) / "fit_dirty_images.fits", hdu=1
     )
 
     assert image.shape == (5, 5)

--- a/test_autogalaxy/interferometer/plot/test_fit_interferometer_plotters.py
+++ b/test_autogalaxy/interferometer/plot/test_fit_interferometer_plotters.py
@@ -1,4 +1,4 @@
-from os import path
+from pathlib import Path
 
 import autogalaxy.plot as aplt
 import pytest
@@ -6,9 +6,7 @@ import pytest
 
 @pytest.fixture(name="plot_path")
 def make_fit_dataset_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "fit"
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "fit"
 
 
 def test__fit_sub_plot_real_space(
@@ -23,7 +21,7 @@ def test__fit_sub_plot_real_space(
         output_format="png",
     )
 
-    assert path.join(plot_path, "fit_real_space.png") in plot_patch.paths
+    assert str(plot_path / "fit_real_space.png") in plot_patch.paths
 
     plot_patch.paths = []
 
@@ -33,4 +31,4 @@ def test__fit_sub_plot_real_space(
         output_format="png",
     )
 
-    assert path.join(plot_path, "fit_real_space.png") in plot_patch.paths
+    assert str(plot_path / "fit_real_space.png") in plot_patch.paths

--- a/test_autogalaxy/interferometer/test_simulate_and_fit_interferometer.py
+++ b/test_autogalaxy/interferometer/test_simulate_and_fit_interferometer.py
@@ -1,11 +1,11 @@
 import os
-from os import path
 import shutil
 
 import numpy as np
 import pytest
 
 import autogalaxy as ag
+from pathlib import Path
 
 
 def test__perfect_fit__chi_squared_0():
@@ -33,27 +33,23 @@ def test__perfect_fit__chi_squared_0():
 
     dataset = simulator.via_galaxies_from(galaxies=[galaxy_0, galaxy_1], grid=grid)
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "data_temp",
-        "simulate_and_fit",
-    )
+    file_path = Path(Path(__file__).resolve().parent) / "data_temp" / "simulate_and_fit"
 
     try:
         shutil.rmtree(file_path)
     except FileNotFoundError:
         pass
 
-    if path.exists(file_path) is False:
+    if Path(file_path).exists() is False:
         os.makedirs(file_path)
 
     from autoarray.dataset.plot.interferometer_plots import fits_interferometer
 
     fits_interferometer(
         dataset=dataset,
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        uv_wavelengths_path=path.join(file_path, "uv_wavelengths.fits"),
+        data_path=Path(file_path) / "data.fits",
+        noise_map_path=Path(file_path) / "noise_map.fits",
+        uv_wavelengths_path=Path(file_path) / "uv_wavelengths.fits",
         overwrite=True,
     )
 
@@ -63,9 +59,9 @@ def test__perfect_fit__chi_squared_0():
     )
 
     dataset = ag.Interferometer.from_fits(
-        data_path=path.join(file_path, "data.fits"),
-        noise_map_path=path.join(file_path, "noise_map.fits"),
-        uv_wavelengths_path=path.join(file_path, "uv_wavelengths.fits"),
+        data_path=Path(file_path) / "data.fits",
+        noise_map_path=Path(file_path) / "noise_map.fits",
+        uv_wavelengths_path=Path(file_path) / "uv_wavelengths.fits",
         real_space_mask=real_space_mask,
         transformer_class=ag.TransformerDFT,
     )
@@ -94,9 +90,7 @@ def test__perfect_fit__chi_squared_0():
     )
     assert abs(fit.chi_squared) < 1.0e-4
 
-    file_path = path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "data_temp"
-    )
+    file_path = Path(Path(__file__).resolve().parent) / "data_temp"
 
     shutil.rmtree(file_path, ignore_errors=True)
 

--- a/test_autogalaxy/plot/mat_wrap/test_visuals.py
+++ b/test_autogalaxy/plot/mat_wrap/test_visuals.py
@@ -1,16 +1,14 @@
-from os import path
+from pathlib import Path
 import pytest
 
 from autogalaxy.operate.lens_calc import LensCalc
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_profile_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "profiles"
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "profiles"
 
 
 def test__1d__half_light_radius_from_light_profile(lp_0):

--- a/test_autogalaxy/profiles/plot/test_basis_plotters.py
+++ b/test_autogalaxy/profiles/plot/test_basis_plotters.py
@@ -1,17 +1,15 @@
-from os import path
 
 import autogalaxy as ag
 import autogalaxy.plot as aplt
 import pytest
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_profile_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "profiles"
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "plots" / "profiles"
 
 
 def test__subplot_image(
@@ -30,4 +28,4 @@ def test__subplot_image(
         output_format="png",
     )
 
-    assert path.join(plot_path, "basis_image.png") in plot_patch.paths
+    assert str(Path(plot_path) / "basis_image.png") in plot_patch.paths

--- a/test_autogalaxy/profiles/plot/test_light_profile_plotters.py
+++ b/test_autogalaxy/profiles/plot/test_light_profile_plotters.py
@@ -1,16 +1,14 @@
-from os import path
 
 import autogalaxy.plot as aplt
 import pytest
+from pathlib import Path
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_profile_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "profiles"
-    )
+    return Path(Path(__file__).resolve().parent) / "files" / "plots" / "profiles"
 
 
 def test__figures_2d__all_are_output(
@@ -27,4 +25,4 @@ def test__figures_2d__all_are_output(
         output_format="png",
     )
 
-    assert path.join(plot_path, "image_2d.png") in plot_patch.paths
+    assert str(Path(plot_path) / "image_2d.png") in plot_patch.paths

--- a/test_autogalaxy/profiles/plot/test_mass_profile_plotters.py
+++ b/test_autogalaxy/profiles/plot/test_mass_profile_plotters.py
@@ -1,18 +1,16 @@
-from os import path
+from pathlib import Path
 
 import autoarray as aa
 import autogalaxy.plot as aplt
 import pytest
 from autogalaxy.operate.lens_calc import LensCalc
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_mp_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))), "files", "plots", "profiles"
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "profiles"
 
 
 def test__figures_2d__all_are_output(
@@ -58,8 +56,8 @@ def test__figures_2d__all_are_output(
         output_format="png",
     )
 
-    assert path.join(plot_path, "convergence_2d.png") in plot_patch.paths
-    assert path.join(plot_path, "potential_2d.png") in plot_patch.paths
-    assert path.join(plot_path, "deflections_y_2d.png") in plot_patch.paths
-    assert path.join(plot_path, "deflections_x_2d.png") in plot_patch.paths
-    assert path.join(plot_path, "magnification_2d.png") in plot_patch.paths
+    assert str(plot_path / "convergence_2d.png") in plot_patch.paths
+    assert str(plot_path / "potential_2d.png") in plot_patch.paths
+    assert str(plot_path / "deflections_y_2d.png") in plot_patch.paths
+    assert str(plot_path / "deflections_x_2d.png") in plot_patch.paths
+    assert str(plot_path / "magnification_2d.png") in plot_patch.paths

--- a/test_autogalaxy/profiles/test_geometry_profiles.py
+++ b/test_autogalaxy/profiles/test_geometry_profiles.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function
 
-from os import path
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -8,7 +8,7 @@ import pytest
 import autogalaxy as ag
 from autogalaxy.profiles import geometry_profiles
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 def test__cos_and_sin_from_x__zero_ell_comps__cos_1_sin_0():

--- a/test_autogalaxy/quantity/model/test_analysis_quantity.py
+++ b/test_autogalaxy/quantity/model/test_analysis_quantity.py
@@ -1,11 +1,11 @@
-from os import path
+from pathlib import Path
 
 import autofit as af
 import autogalaxy as ag
 
 from autogalaxy.quantity.model.result import ResultQuantity
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 class TestAnalysisQuantity:

--- a/test_autogalaxy/quantity/model/test_plotter_quantity.py
+++ b/test_autogalaxy/quantity/model/test_plotter_quantity.py
@@ -1,17 +1,17 @@
 import shutil
-from os import path
 import pytest
 
 import autogalaxy as ag
 
 from autogalaxy.quantity.model.plotter import PlotterQuantity
+from pathlib import Path
 
-directory = path.dirname(path.abspath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_plotter_plotter_setup():
-    return path.join("{}".format(directory), "files")
+    return directory / "files"
 
 
 def test__dataset(
@@ -19,7 +19,7 @@ def test__dataset(
     plot_path,
     plot_patch,
 ):
-    if path.exists(plot_path):
+    if Path(plot_path).exists():
         shutil.rmtree(plot_path)
 
     plotter = PlotterQuantity(image_path=plot_path)
@@ -27,7 +27,7 @@ def test__dataset(
     plotter.dataset_quantity(dataset=dataset_quantity_7x7_array_2d)
 
     image = ag.ndarray_via_fits_from(
-        file_path=path.join(plot_path, "dataset.fits"), hdu=1
+        file_path=Path(plot_path) / "dataset.fits", hdu=1
     )
 
     assert image.shape == (7, 7)
@@ -39,11 +39,11 @@ def test__fit_quantity(
     plot_path,
     plot_patch,
 ):
-    if path.exists(plot_path):
+    if Path(plot_path).exists():
         shutil.rmtree(plot_path)
 
     plotter = PlotterQuantity(image_path=plot_path)
 
     plotter.fit_quantity(fit=fit_quantity_7x7_array_2d)
 
-    assert path.join(plot_path, "fit.png") not in plot_patch.paths
+    assert str(Path(plot_path) / "fit.png") not in plot_patch.paths

--- a/test_autogalaxy/quantity/plot/test_fit_quantity_plotters.py
+++ b/test_autogalaxy/quantity/plot/test_fit_quantity_plotters.py
@@ -1,20 +1,15 @@
-from os import path
+from pathlib import Path
 
 import pytest
 
 import autogalaxy.plot as aplt
 
-directory = path.dirname(path.realpath(__file__))
+directory = Path(__file__).resolve().parent
 
 
 @pytest.fixture(name="plot_path")
 def make_galaxy_fit_plotter_setup():
-    return path.join(
-        "{}".format(path.dirname(path.realpath(__file__))),
-        "files",
-        "plots",
-        "galaxy_fitting",
-    )
+    return Path(__file__).resolve().parent / "files" / "plots" / "galaxy_fitting"
 
 
 def test__fit_sub_plot__all_types_of_fit(
@@ -28,4 +23,4 @@ def test__fit_sub_plot__all_types_of_fit(
         output_path=plot_path,
         output_format="png",
     )
-    assert path.join(plot_path, "fit.png") in plot_patch.paths
+    assert str(plot_path / "fit.png") in plot_patch.paths

--- a/test_autogalaxy/quantity/test_dataset_quantity.py
+++ b/test_autogalaxy/quantity/test_dataset_quantity.py
@@ -1,10 +1,10 @@
 import numpy as np
 import os
-from os import path
 import pytest
 import shutil
 
 import autogalaxy as ag
+from pathlib import Path
 
 
 def test__via_signal_to_noise_map__array_2d_data__correct_noise_map(
@@ -134,14 +134,9 @@ def test__vector_data__y_x():
 
 @pytest.fixture(name="test_data_path")
 def make_test_data_path():
-    test_data_path = path.join(
-        "{}".format(os.path.dirname(os.path.realpath(__file__))),
-        "files",
-        "array",
-        "output_test",
-    )
+    test_data_path = Path(__file__).resolve().parent / "files" / "array" / "output_test"
 
-    if os.path.exists(test_data_path):
+    if test_data_path.exists():
         shutil.rmtree(test_data_path)
 
     os.makedirs(test_data_path)
@@ -156,22 +151,22 @@ def test__output_to_fits__array_2d_data__data_and_noise_map_written_correctly(
 
     output_to_fits(
         values=dataset_quantity_7x7_array_2d.data.native.array.astype("float"),
-        file_path=path.join(test_data_path, "data.fits"),
+        file_path=Path(test_data_path) / "data.fits",
         overwrite=True,
         header_dict=dataset_quantity_7x7_array_2d.data.mask.header_dict,
     )
     output_to_fits(
         values=dataset_quantity_7x7_array_2d.noise_map.native.array.astype("float"),
-        file_path=path.join(test_data_path, "noise_map.fits"),
+        file_path=Path(test_data_path) / "noise_map.fits",
         overwrite=True,
         header_dict=dataset_quantity_7x7_array_2d.noise_map.mask.header_dict,
     )
 
     data = ag.Array2D.from_fits(
-        file_path=path.join(test_data_path, "data.fits"), hdu=0, pixel_scales=1.0
+        file_path=Path(test_data_path) / "data.fits", hdu=0, pixel_scales=1.0
     )
     noise_map = ag.Array2D.from_fits(
-        file_path=path.join(test_data_path, "noise_map.fits"), hdu=0, pixel_scales=1.0
+        file_path=Path(test_data_path) / "noise_map.fits", hdu=0, pixel_scales=1.0
     )
 
     assert (data.native == np.ones((7, 7))).all()
@@ -197,19 +192,19 @@ def test__output_to_fits__vector_yx_2d_data__first_pixel_written_correctly(
 
     output_to_fits(
         values=dataset_quantity.data.native.array.astype("float"),
-        file_path=path.join(test_data_path, "data.fits"),
+        file_path=Path(test_data_path) / "data.fits",
         overwrite=True,
         header_dict=dataset_quantity.data.mask.header_dict,
     )
     output_to_fits(
         values=dataset_quantity.noise_map.native.array.astype("float"),
-        file_path=path.join(test_data_path, "noise_map.fits"),
+        file_path=Path(test_data_path) / "noise_map.fits",
         overwrite=True,
         header_dict=dataset_quantity.noise_map.mask.header_dict,
     )
 
     data = ag.Array2D.from_fits(
-        file_path=path.join(test_data_path, "data.fits"), hdu=0, pixel_scales=1.0
+        file_path=Path(test_data_path) / "data.fits", hdu=0, pixel_scales=1.0
     )
 
     assert data[0, 0] == pytest.approx([1.0, 5.0], 1.0e-4)


### PR DESCRIPTION
## Summary

Mechanical refactor replacing all `os.path.*` and bare `path.*` (from `from os import path`) usages with `pathlib.Path`. Part of cross-repo issue PyAutoLabs/PyAutoFit#1257 — the codebase already used `pathlib` extensively in newer code; this sweeps up the remaining legacy usages for consistency.

## API Changes

None — internal changes only. All public function signatures unchanged. Implementation switches from string-style joins to Path objects, but returned values, accepted argument types, and external behaviour are unchanged. Some test fixtures (`PlotPatch`) now stringify recorded paths to keep assertions stable.

See full details below.

## Test Plan

- [ ] `python -m pytest test_<repo>/` passes (CI)
- [ ] Verified locally as part of cross-repo sweep (3,188 tests across PyAutoConf/PyAutoFit/PyAutoArray/PyAutoGalaxy/PyAutoLens)
- [ ] No public API changed — workspace scripts should be unaffected (separate workspace PR follows for tutorial/example consistency)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None — no public symbols removed

### Added
- None — no new public symbols

### Renamed
- None

### Changed Signature
- None

### Changed Behaviour
- None observable. Internal helpers now build paths with `Path / "..."` instead of `os.path.join`, but consumers that accept `str | os.PathLike` see the same effective path.

### Migration
- No user migration needed.

</details>

Refs PyAutoLabs/PyAutoFit#1257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)