### PR TITLE
feat: dispatch autogalaxy visualizers via fit_for_visualization

### DIFF
--- a/autogalaxy/imaging/model/visualizer.py
+++ b/autogalaxy/imaging/model/visualizer.py
@@ -76,7 +76,7 @@ class VisualizerImaging(af.Visualizer):
             An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
             via a non-linear search).
         """
-        fit = analysis.fit_from(instance=instance)
+        fit = analysis.fit_for_visualization(instance=instance)
 
         plotter = PlotterImaging(
             image_path=paths.image_path, title_prefix=analysis.title_prefix
@@ -173,7 +173,7 @@ class VisualizerImaging(af.Visualizer):
         )
 
         fit_list = [
-            analysis.fit_from(instance=single_instance)
+            analysis.fit_for_visualization(instance=single_instance)
             for analysis, single_instance in zip(analyses, instance)
         ]
 

--- a/autogalaxy/interferometer/model/visualizer.py
+++ b/autogalaxy/interferometer/model/visualizer.py
@@ -78,7 +78,7 @@ class VisualizerInterferometer(af.Visualizer):
             An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
             via a non-linear search).
         """
-        fit = analysis.fit_from(instance=instance)
+        fit = analysis.fit_for_visualization(instance=instance)
 
         plotter = PlotterInterferometer(
             image_path=paths.image_path, title_prefix=analysis.title_prefix


### PR DESCRIPTION
## Summary

PyAutoLens visualizers were updated in #443 (2026-04-19) to dispatch through `analysis.fit_for_visualization(instance=instance)` so the fit reused for plotting goes through autofit's cached `jax.jit` wrapper when `use_jax_for_visualization=True`. PyAutoGalaxy received matching pytree registration for `FitImaging` (#364) and `FitInterferometer` (#376) but the visualizer dispatch was never switched over for either. As a result `use_jax_for_visualization=True` on `ag.AnalysisImaging` / `AnalysisInterferometer` was a silent no-op for visualization. This PR swaps the three call sites.

The change is safe for the NumPy default path because `fit_for_visualization` falls back to `fit_from` whenever `use_jax_for_visualization=False`.

Closes #389.

## API Changes

None — internal changes only. The visualizer call sites are private; users construct `Analysis` instances and the visualizer is invoked by the search machinery, never called directly. Behaviour is unchanged on the NumPy path. JAX users who set ``use_jax_for_visualization=True`` now actually get the jit-cached path that the pytree registration was set up for.

See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/imaging/model/ test_autogalaxy/interferometer/model/` — 14 tests pass
- [x] Broader sweep: `pytest test_autogalaxy/imaging/ test_autogalaxy/interferometer/`
- [ ] `/smoke_test autogalaxy_workspace_test imaging/visualization.py imaging/visualization_jax.py interferometer/visualization.py` — to be run after merge as part of the JAX visualization roadmap follow-up

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour

- `autogalaxy.imaging.model.visualizer.VisualizerImaging.visualize` — now dispatches through `analysis.fit_for_visualization(instance=...)` instead of `analysis.fit_from(instance=...)`. Behaviour identical when `use_jax_for_visualization=False` (default). When `True`, uses the cached `jax.jit` wrapper from autofit.
- `autogalaxy.imaging.model.visualizer.VisualizerImaging.visualize_combined` — same swap inside the per-analysis fit list comprehension that builds combined-fit images for multi-analysis searches.
- `autogalaxy.interferometer.model.visualizer.VisualizerInterferometer.visualize` — same swap (single-analysis path; no `visualize_combined` exists for interferometer in autogalaxy).

### Migration

None required. `fit_for_visualization` was added to autofit's base `Analysis` (PyAutoFit #1228) and silently falls back to `fit_from` when the JAX visualization flag is off — so any caller that previously worked with `fit_from` continues to work.

### Roadmap context

This is **Phase 0b** of `PyAutoPrompt/z_features/jax_visualization.md`. It unblocks the autogalaxy interferometer visualization scripts in `autogalaxy_workspace_test` (Phase 1C) and the eventual default-on flip of `use_jax_for_visualization` (Phase 2).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)