### PR TITLE
refactor: DatasetInterp delegates to aa.interp_2d; expose xp

### DIFF
--- a/autogalaxy/ellipse/dataset_interp.py
+++ b/autogalaxy/ellipse/dataset_interp.py
@@ -43,45 +43,79 @@ class DatasetInterp:
 
         return (x, y)
 
-    @cached_property
-    def mask_interp(self) -> "interpolate.RegularGridInterpolator":
+    def mask_interp(self, points, xp=np):
         """
         Returns a 2D interpolation of the mask, which is used to determine whether inteprolated values use a masked
         pixel for the interpolation and thus should not be included in a fit.
-        """
-        from scipy import interpolate
 
-        return interpolate.RegularGridInterpolator(
-            points=self.points_interp,
-            values=np.float64(self.dataset.data.mask),
-            bounds_error=False,
+        Backwards-compatibility note: this used to be a cached property that
+        returned a scipy ``RegularGridInterpolator`` instance, also callable on
+        ``(N, 2)`` points. Existing call sites in ``fit_ellipse.py`` that read
+        ``self.interp.mask_interp(points)`` continue to work; the sentinel
+        check ``self.interp.mask_interp is not None`` also continues to pass
+        (a bound method is never None).
+
+        Parameters
+        ----------
+        points
+            An ``(N, 2)`` array of query coordinates. Out-of-bounds queries
+            return 0.0 (treat outside-the-grid as unmasked).
+        xp
+            Array namespace (``numpy`` or ``jax.numpy``). Defaults to
+            ``numpy``.
+        """
+        x_axis, y_axis = self.points_interp
+        return aa.numerics.interp_2d(
+            points,
+            x_axis,
+            y_axis,
+            np.float64(self.dataset.data.mask),
             fill_value=0.0,
+            xp=xp,
         )
 
-    @cached_property
-    def data_interp(self) -> "interpolate.RegularGridInterpolator":
+    def data_interp(self, points, xp=np):
         """
         Returns a 2D interpolation of the data, which is used to evaluate the data at any point in 2D space.
-        """
-        from scipy import interpolate
 
-        return interpolate.RegularGridInterpolator(
-            points=self.points_interp,
-            values=np.float64(self.dataset.data.native),
-            bounds_error=False,
+        Parameters
+        ----------
+        points
+            An ``(N, 2)`` array of query coordinates. Out-of-bounds queries
+            return 0.0.
+        xp
+            Array namespace (``numpy`` or ``jax.numpy``). Defaults to
+            ``numpy``.
+        """
+        x_axis, y_axis = self.points_interp
+        return aa.numerics.interp_2d(
+            points,
+            x_axis,
+            y_axis,
+            np.float64(self.dataset.data.native),
             fill_value=0.0,
+            xp=xp,
         )
 
-    @cached_property
-    def noise_map_interp(self) -> "interpolate.RegularGridInterpolator":
+    def noise_map_interp(self, points, xp=np):
         """
         Returns a 2D interpolation of the noise-map, which is used to evaluate the noise-map at any point in 2D space.
-        """
-        from scipy import interpolate
 
-        return interpolate.RegularGridInterpolator(
-            points=self.points_interp,
-            values=np.float64(self.dataset.noise_map.native),
-            bounds_error=False,
+        Parameters
+        ----------
+        points
+            An ``(N, 2)`` array of query coordinates. Out-of-bounds queries
+            return 0.0.
+        xp
+            Array namespace (``numpy`` or ``jax.numpy``). Defaults to
+            ``numpy``.
+        """
+        x_axis, y_axis = self.points_interp
+        return aa.numerics.interp_2d(
+            points,
+            x_axis,
+            y_axis,
+            np.float64(self.dataset.noise_map.native),
             fill_value=0.0,
+            xp=xp,
         )

--- a/autogalaxy/ellipse/dataset_interp.py
+++ b/autogalaxy/ellipse/dataset_interp.py
@@ -65,7 +65,7 @@ class DatasetInterp:
             ``numpy``.
         """
         x_axis, y_axis = self.points_interp
-        return aa.numerics.interp_2d(
+        return aa.interp_2d(
             points,
             x_axis,
             y_axis,
@@ -88,7 +88,7 @@ class DatasetInterp:
             ``numpy``.
         """
         x_axis, y_axis = self.points_interp
-        return aa.numerics.interp_2d(
+        return aa.interp_2d(
             points,
             x_axis,
             y_axis,
@@ -111,7 +111,7 @@ class DatasetInterp:
             ``numpy``.
         """
         x_axis, y_axis = self.points_interp
-        return aa.numerics.interp_2d(
+        return aa.interp_2d(
             points,
             x_axis,
             y_axis,


### PR DESCRIPTION
## Summary

Refactor `DatasetInterp` in `autogalaxy/ellipse/dataset_interp.py` to delegate 2D interpolation to the new `aa.interp_2d` helper (shipped in PyAutoArray PR https://github.com/PyAutoLabs/PyAutoArray/pull/308) and to expose an `xp` parameter for the JAX path. Step 4 of the `ellipse_fitting_jax` feature — `DatasetInterp` was the first hard JAX blocker for `AnalysisEllipse.log_likelihood_function`. NumPy-path behaviour is byte-stable: the prompt-3 reference arrays pin `_points_from_major_axis` to `rtol=1e-12` and pass unchanged; the prompt-2 workspace_test reference numbers match to all 8 printed decimal places.

## API Changes

`DatasetInterp.{mask,data,noise_map}_interp` changed from `@cached_property` returning `scipy.interpolate.RegularGridInterpolator` instances to methods `(points, xp=np)` that return the interpolated `(N,)` array directly. The original "use the interpolator like a callable" pattern (`interp_obj(points)`) is preserved — `ds.mask_interp(points)` still works. The "store the interpolator and re-use" pattern (`interp = ds.mask_interp; interp(pts_a); interp(pts_b)`) breaks. No known external users follow that pattern. The sentinel check `self.interp.mask_interp is not None` in `fit_ellipse.py:81` is preserved (still always True; a bound method is non-None). See full details below.

## Test Plan

- [ ] `python -m pytest test_autogalaxy/ellipse/ -v` — 30/30 pass, including prompt-3's `rtol=1e-12` `_points_from_major_axis` pins
- [ ] `python -m pytest test_autogalaxy/ -x` — 858/858 pass
- [ ] `python scripts/jax_likelihood_functions/ellipse/{fit,multipoles}.py` from `autogalaxy_workspace_test/` — all 8 reference numbers match prompt-2 baseline byte-for-byte

## Upstream PR

https://github.com/PyAutoLabs/PyAutoArray/pull/308

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None — the property names are kept; their *kind* (property → method) changes.

### Changed Behaviour
- `autogalaxy.ellipse.DatasetInterp.mask_interp` — was `@cached_property` returning `scipy.interpolate.RegularGridInterpolator`; now method `(points, xp=np)` returning `np.ndarray` or `jax.Array` directly.
- `autogalaxy.ellipse.DatasetInterp.data_interp` — same.
- `autogalaxy.ellipse.DatasetInterp.noise_map_interp` — same.

### Migration
- `ds.mask_interp(points)` — no change.
- `interp = ds.mask_interp; interp(points)` — replace with `ds.mask_interp(points)` (call inline, don't store the bound method as a substitute for an interpolator instance).
- New JAX path: `ds.mask_interp(points, xp=jnp)` returns a `jax.Array`. Not exercised in this PR — wired into the analysis class by prompt 7.

</details>

Generated with [Claude Code](https://claude.com/claude-code)