### PR TITLE
fix: ag.AnalysisInterferometer.__init__ kwargs passthrough

### DIFF
--- a/autogalaxy/interferometer/model/analysis.py
+++ b/autogalaxy/interferometer/model/analysis.py
@@ -42,6 +42,7 @@ class AnalysisInterferometer(AnalysisDataset):
         settings: aa.Settings = None,
         title_prefix: str = None,
         use_jax: bool = True,
+        **kwargs,
     ):
         """
         Fits a galaxy model to an interferometer dataset via a non-linear search.
@@ -80,6 +81,7 @@ class AnalysisInterferometer(AnalysisDataset):
             settings=settings,
             title_prefix=title_prefix,
             use_jax=use_jax,
+            **kwargs,
         )
 
     @property


### PR DESCRIPTION
## Summary

`ag.AnalysisInterferometer.__init__` defined its own explicit signature without `**kwargs`, so any kwarg not in its named-parameter list (notably `use_jax_for_visualization` from the autofit base `Analysis`) raised `TypeError` instead of being forwarded to super.

This left `use_jax_for_visualization=True` silently unusable on `ag.AnalysisInterferometer` despite:
- the autogalaxy interferometer visualizer already dispatching via `fit_for_visualization` (`autogalaxy/interferometer/model/visualizer.py:81`, shipped in #390)
- `AnalysisInterferometer` having full pytree registration via `_register_fit_interferometer_pytrees` (PR #376)

This PR adds `**kwargs` to the parameter list and forwards it in the `super().__init__()` call. `AnalysisDataset` (the parent) already accepts and forwards `**kwargs`. `ag.AnalysisImaging` has had this passthrough all along.

Mirrors the same kwargs-gap fixes shipped for PyAutoLens `AnalysisInterferometer` (PyAutoLens #500) and `AnalysisPoint` (PyAutoLens #506). With this PR, **all four Analysis subclasses across PyAutoLens + PyAutoGalaxy** now accept `use_jax_for_visualization` without `TypeError`.

Unblocks Phase 1C of the JAX visualization roadmap (`PyAutoPrompt/autogalaxy_workspace_test/jax_viz_dataset_coverage.md`).

## API Changes

`ag.AnalysisInterferometer.__init__` gains a `**kwargs` passthrough — strictly additive. Any caller that previously worked is unaffected. New: callers can now pass `use_jax_for_visualization=True` (or any other kwarg accepted by the autofit base `Analysis`) without `TypeError`.

See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/interferometer/` — 37 tests pass

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Signature

- `ag.AnalysisInterferometer.__init__` now accepts `**kwargs` and forwards them to `super().__init__()`. Strictly additive — no existing call site is affected.

### Migration

None required. Callers that previously passed only the named arguments continue to work.

### Completes the kwargs-gap series

- `al.AnalysisImaging` — always had `**kwargs` ✓
- `al.AnalysisInterferometer` — fixed in PyAutoLens #500 ✓
- `al.AnalysisPoint` — fixed in PyAutoLens #506 ✓
- `ag.AnalysisImaging` — always had `**kwargs` ✓
- `ag.AnalysisInterferometer` — this PR ✓

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)