### PR TITLE
feat: pytree registration for FitEllipse + FitQuantity (Phase 0c)

### DIFF
--- a/autogalaxy/ellipse/model/analysis.py
+++ b/autogalaxy/ellipse/model/analysis.py
@@ -33,7 +33,11 @@ class AnalysisEllipse(af.Analysis):
     Visualizer = VisualizerEllipse
 
     def __init__(
-        self, dataset: aa.Imaging, title_prefix: str = None, use_jax: bool = False
+        self,
+        dataset: aa.Imaging,
+        title_prefix: str = None,
+        use_jax: bool = False,
+        **kwargs,
     ):
         """
         Fits a model made of ellipses to an imaging dataset via a non-linear search.
@@ -57,7 +61,30 @@ class AnalysisEllipse(af.Analysis):
         self.dataset = dataset
         self.title_prefix = title_prefix
 
-        super().__init__(use_jax=use_jax)
+        super().__init__(use_jax=use_jax, **kwargs)
+
+        if use_jax:
+            self._register_fit_ellipse_pytrees()
+
+    @staticmethod
+    def _register_fit_ellipse_pytrees() -> None:
+        """Register every type reachable from a ``FitEllipse`` return value so
+        ``jax.jit`` can flatten its output.
+
+        ``dataset`` is per-analysis-constant — ride as aux so JAX does not
+        recurse into it. ``ellipse`` and ``multipole_list`` carry the
+        traced model parameters (``centre``, ``ell_comps``, ``major_axis``,
+        ``multipole_comps``).
+        """
+        from autoarray.abstract_ndarray import register_instance_pytree
+        from autogalaxy.ellipse.ellipse.ellipse import Ellipse
+        from autogalaxy.ellipse.ellipse.ellipse_multipole import EllipseMultipole
+
+        register_instance_pytree(Ellipse)
+        # ``m`` is the multipole order (integer discriminator like 4, 6 — not
+        # fittable). The traced parameters live in ``multipole_comps``.
+        register_instance_pytree(EllipseMultipole, no_flatten=("m",))
+        register_instance_pytree(FitEllipse, no_flatten=("dataset",))
 
     def log_likelihood_function(self, instance: af.ModelInstance) -> float:
         """

--- a/autogalaxy/quantity/model/analysis.py
+++ b/autogalaxy/quantity/model/analysis.py
@@ -23,6 +23,7 @@ class AnalysisQuantity(Analysis):
         cosmology: LensingCosmology = None,
         title_prefix: str = None,
         use_jax: bool = True,
+        **kwargs,
     ):
         """
         Fits a galaxy model to a quantity dataset via a non-linear search.
@@ -57,11 +58,33 @@ class AnalysisQuantity(Analysis):
             A string that is added before the title of all figures output by visualization, for example to
             put the name of the dataset and galaxy in the title.
         """
-        super().__init__(cosmology=cosmology, use_jax=use_jax)
+        super().__init__(cosmology=cosmology, use_jax=use_jax, **kwargs)
 
         self.dataset = dataset
         self.func_str = func_str
         self.title_prefix = title_prefix
+
+        if use_jax:
+            self._register_fit_quantity_pytrees()
+
+    @staticmethod
+    def _register_fit_quantity_pytrees() -> None:
+        """Register every type reachable from a ``FitQuantity`` return value
+        so ``jax.jit`` can flatten its output.
+
+        ``dataset``, ``func_str``, ``use_mask_in_fit`` are per-analysis-
+        constant — ride as aux so JAX does not recurse into them.
+        ``light_mass_obj`` (a ``Galaxies``) and ``model_data_manual``
+        carry the traced model arrays and ride as pytree children.
+        """
+        from autoarray.abstract_ndarray import register_instance_pytree
+        from autogalaxy.analysis.jax_pytrees import register_galaxies_pytree
+
+        register_instance_pytree(
+            FitQuantity,
+            no_flatten=("dataset", "func_str", "use_mask_in_fit"),
+        )
+        register_galaxies_pytree()
 
     def log_likelihood_function(self, instance: af.ModelInstance) -> float:
         """


### PR DESCRIPTION
## Summary

Phase 0c of the JAX visualization roadmap. PyAutoGalaxy's `FitImaging` and `FitInterferometer` are JAX pytree-registered (PRs #364 and #376). This PR completes the autogalaxy side by registering `FitEllipse` and `FitQuantity` so `jax.jit`-wrapped functions returning either fit type can lift them across the JIT boundary.

Also adds `**kwargs` passthrough on `ag.AnalysisEllipse.__init__` and `ag.AnalysisQuantity.__init__` (parity with #399's `ag.AnalysisInterferometer` fix).

Closes #400.

## API Changes

- `ag.AnalysisEllipse.__init__` and `ag.AnalysisQuantity.__init__` gain `**kwargs` passthrough — strictly additive. Callers can now pass `use_jax_for_visualization=True` (and any other autofit-base `Analysis` kwarg) without `TypeError`.
- New `_register_fit_ellipse_pytrees` and `_register_fit_quantity_pytrees` static methods on the respective analysis classes, invoked under `if use_jax:`. They register `Ellipse`, `EllipseMultipole`, `FitEllipse`, `FitQuantity`, and reuse `register_galaxies_pytree()` for the `Galaxies` aggregate inside `FitQuantity.light_mass_obj`.

See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/{ellipse,quantity,imaging,interferometer}/` — 154 tests pass.
- [x] Interactive round-trip smoke (local):
  - `FitEllipse`: 8 dynamic leaves; `ellipse.centre`, `ell_comps`, `major_axis` survive `tree_flatten`/`tree_unflatten`.
  - `FitQuantity`: 3 dynamic leaves; `light_mass_obj` reconstructed as `Galaxies`, `dataset` retained as aux constant, `func_str` preserved.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Signature

- `ag.AnalysisEllipse.__init__` and `ag.AnalysisQuantity.__init__` now accept `**kwargs` and forward them to `super().__init__()`. Strictly additive — no existing call site is affected.

### Added (internal)

- `ag.AnalysisEllipse._register_fit_ellipse_pytrees` — registers `Ellipse`, `EllipseMultipole(no_flatten=("m",))`, `FitEllipse(no_flatten=("dataset",))` as JAX pytrees. Fires once per process when an `AnalysisEllipse` is constructed with `use_jax=True`.
- `ag.AnalysisQuantity._register_fit_quantity_pytrees` — registers `FitQuantity(no_flatten=("dataset", "func_str", "use_mask_in_fit"))` and reuses `autogalaxy.analysis.jax_pytrees.register_galaxies_pytree()` for the `light_mass_obj`.

### Dynamic vs static split

| Class | Dynamic (traced) | Static (`no_flatten`/aux) |
|---|---|---|
| `Ellipse` | `centre`, `ell_comps`, `major_axis` (all `__dict__`) | — |
| `EllipseMultipole` | `multipole_comps` | `m` (integer order) |
| `FitEllipse` | `ellipse`, `multipole_list` | `dataset` |
| `FitQuantity` | `light_mass_obj`, `model_data_manual` | `dataset`, `func_str`, `use_mask_in_fit` |

### Out of scope (deferred to follow-ups)

- **Visualizer dispatch swap** for `ag.AnalysisEllipse` and `ag.AnalysisQuantity`. Both currently bypass `analysis.fit_for_visualization` entirely (`VisualizerEllipse.visualize` calls `analysis.fit_list_from`; `VisualizerQuantity.visualize` calls `analysis.fit_quantity_for_instance`). `use_jax_for_visualization=True` therefore remains a no-op for these analyses until a separate task wires the dispatch — straightforward for quantity (singular fit return), needs design for ellipse (list return).
- **Phase 1C** (autogalaxy_workspace_test JAX viz coverage scripts) — will exercise these registrations end-to-end once the visualizer dispatch follow-up lands.

### Migration

None required.

### Completes the autogalaxy pytree series

- `ag.FitImaging` — PR #364 ✓
- `ag.FitInterferometer` — PR #376 ✓
- `ag.FitEllipse` + `ag.FitQuantity` — this PR ✓

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)