### PR TITLE
docs(research): Ludlow16 JAX concentration feasibility study (#397)

### DIFF
--- a/docs/research/nfw_ludlow16_jax/bench.py
+++ b/docs/research/nfw_ludlow16_jax/bench.py
@@ -1,0 +1,121 @@
+"""
+Benchmark the JAX prototype against colossus, and exercise grad + vmap
+to confirm the JAX path supports differentiation and vectorisation —
+the two capabilities the pure_callback rules out.
+
+Run with:
+    NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \
+        JAX_ENABLE_X64=1 python docs/research/nfw_ludlow16_jax/bench.py
+"""
+
+import os
+import time
+import numpy as np
+
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+
+from colossus.cosmology import cosmology as col_cosmology
+from colossus.halo.concentration import concentration as col_concentration
+
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+from ludlow16_jax import ludlow16_concentration_jax  # noqa: E402
+
+
+PLANCK15 = dict(
+    h=0.6774,
+    Om0=0.3089,
+    Ob0=0.0486,
+    Tcmb0=2.7255,
+    sigma8=0.8159,
+    ns=0.9667,
+)
+
+
+def main():
+    col_cosmology.setCosmology("planck15")
+
+    # ----------------------------------------------------------------
+    # 1) grad — does jax.grad work through the concentration solver?
+    # ----------------------------------------------------------------
+
+    @jax.jit
+    def c_of_M(M):
+        return ludlow16_concentration_jax(M, 0.5, **PLANCK15)
+
+    print("grad test:")
+    M0 = jnp.float64(1.0e12)
+    c0 = c_of_M(M0)
+    g = jax.grad(c_of_M)(M0)
+    print(f"  c(1e12, z=0.5) = {float(c0):.4f}")
+    print(f"  dc/dM         = {float(g):.4e}")
+
+    # Finite-difference check using colossus
+    eps = 1.0e9
+    c_low = float(col_concentration(1.0e12 - eps, "200c", 0.5, model="ludlow16"))
+    c_high = float(col_concentration(1.0e12 + eps, "200c", 0.5, model="ludlow16"))
+    g_fd = (c_high - c_low) / (2 * eps)
+    print(f"  dc/dM (fd)    = {g_fd:.4e}")
+    print(f"  agreement: rel err = {abs(g - g_fd) / abs(g_fd):.2e}")
+    print()
+
+    # ----------------------------------------------------------------
+    # 2) vmap — batch many (M, z) pairs in one JIT trace
+    # ----------------------------------------------------------------
+
+    @jax.jit
+    def c_single(M, z):
+        return ludlow16_concentration_jax(M, z, **PLANCK15)
+
+    batch_size = 32
+    M_batch = jnp.geomspace(1.0e10, 1.0e14, batch_size)
+    z_batch = jnp.linspace(0.1, 2.5, batch_size)
+
+    c_batched = jax.jit(jax.vmap(c_single))
+    # warm up
+    _ = c_batched(M_batch, z_batch).block_until_ready()
+
+    n_iter = 20
+    t0 = time.perf_counter()
+    for _ in range(n_iter):
+        _ = c_batched(M_batch, z_batch).block_until_ready()
+    t_jax_batch = (time.perf_counter() - t0) / n_iter
+
+    t0 = time.perf_counter()
+    for _ in range(n_iter):
+        for M, z in zip(np.array(M_batch), np.array(z_batch)):
+            _ = col_concentration(float(M), "200c", float(z), model="ludlow16")
+    t_col_batch = (time.perf_counter() - t0) / n_iter
+
+    print(f"Batch of {batch_size} concentration calls:")
+    print(f"  colossus (serial)         : {t_col_batch*1e3:.2f} ms")
+    print(f"  jax vmap (post-jit)       : {t_jax_batch*1e3:.2f} ms")
+    print(f"  speedup                   : {t_col_batch / t_jax_batch:.2f}x")
+    print()
+
+    # ----------------------------------------------------------------
+    # 3) Single-call wall time, including JIT compile vs post-compile
+    # ----------------------------------------------------------------
+
+    fresh_jit = jax.jit(
+        lambda M, z: ludlow16_concentration_jax(M, z, **PLANCK15)
+    )
+    t0 = time.perf_counter()
+    _ = fresh_jit(1.0e12, 0.5).block_until_ready()
+    t_compile = time.perf_counter() - t0
+    print(f"JIT compile + first call: {t_compile*1e3:.1f} ms")
+
+    n_iter = 100
+    t0 = time.perf_counter()
+    for _ in range(n_iter):
+        _ = fresh_jit(1.0e12, 0.5).block_until_ready()
+    t_post = (time.perf_counter() - t0) / n_iter
+    print(f"Post-compile single call: {t_post*1e3:.3f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/nfw_ludlow16_jax/ludlow16_jax.py
+++ b/docs/research/nfw_ludlow16_jax/ludlow16_jax.py
@@ -1,0 +1,401 @@
+"""
+Approach A prototype: a fully JAX-native port of the Ludlow et al. 2016
+mass-concentration relation, replacing the `colossus.halo.concentration.modelLudlow16`
+call currently wrapped by `jax.pure_callback` in
+`autogalaxy/profiles/mass/dark/mcr_util.py`.
+
+Algorithm structure follows colossus' `modelLudlow16` (concentration.py, lines
+1104-1192) and `modelEisenstein98` (power_spectrum.py, lines 476-608) exactly.
+Re-derivations inline below where the JAX form differs from the numpy original.
+
+Inputs/outputs match colossus:
+    M200c is in Msun / h
+    R is in Mpc / h
+    z is dimensionless redshift
+    Cosmology parameters: h, Om0, Ob0, Tcmb0, sigma8, ns
+"""
+
+import jax
+import jax.numpy as jnp
+from jax.scipy.special import gammainc, erfc
+
+
+# ---------------------------------------------------------------------------
+# Eisenstein & Hu 1998 transfer function
+# Direct port of colossus.cosmology.power_spectrum.modelEisenstein98
+# ---------------------------------------------------------------------------
+
+
+def transfer_eh98(k, h, Om0, Ob0, Tcmb0):
+    """
+    EH98 transfer function T(k) including baryon acoustic features.
+
+    Parameters
+    ----------
+    k : array_like
+        Wavenumber in comoving h/Mpc.
+    h, Om0, Ob0 : floats
+        Cosmology (Hubble parameter / 100; matter, baryon densities).
+    Tcmb0 : float
+        CMB temperature today in Kelvin.
+
+    Returns
+    -------
+    Tk : jnp.ndarray
+        Transfer function value(s); same shape as k.
+    """
+    omc = Om0 - Ob0
+    ombom0 = Ob0 / Om0
+    h2 = h ** 2
+    om0h2 = Om0 * h2
+    ombh2 = Ob0 * h2
+    theta2p7 = Tcmb0 / 2.7
+    theta2p72 = theta2p7 ** 2
+    theta2p74 = theta2p72 ** 2
+
+    # k in colossus is comoving h/Mpc; internal kh is in 1/Mpc.
+    kh = k * h
+
+    zeq = 2.50e4 * om0h2 / theta2p74
+    keq = 7.46e-2 * om0h2 / theta2p72
+
+    b1d = 0.313 * om0h2 ** -0.419 * (1.0 + 0.607 * om0h2 ** 0.674)
+    b2d = 0.238 * om0h2 ** 0.223
+    zd = 1291.0 * om0h2 ** 0.251 / (1.0 + 0.659 * om0h2 ** 0.828) * (
+        1.0 + b1d * ombh2 ** b2d
+    )
+
+    Rd = 31.5 * ombh2 / theta2p74 / (zd / 1e3)
+    Req = 31.5 * ombh2 / theta2p74 / (zeq / 1e3)
+
+    s = (
+        2.0
+        / 3.0
+        / keq
+        * jnp.sqrt(6.0 / Req)
+        * jnp.log(
+            (jnp.sqrt(1.0 + Rd) + jnp.sqrt(Rd + Req)) / (1.0 + jnp.sqrt(Req))
+        )
+    )
+
+    ksilk = 1.6 * ombh2 ** 0.52 * om0h2 ** 0.73 * (1.0 + (10.4 * om0h2) ** -0.95)
+
+    q = kh / 13.41 / keq
+
+    a1 = (46.9 * om0h2) ** 0.670 * (1.0 + (32.1 * om0h2) ** -0.532)
+    a2 = (12.0 * om0h2) ** 0.424 * (1.0 + (45.0 * om0h2) ** -0.582)
+    ac = a1 ** (-ombom0) * a2 ** (-(ombom0 ** 3))
+
+    b1 = 0.944 / (1.0 + (458.0 * om0h2) ** -0.708)
+    b2 = (0.395 * om0h2) ** -0.0266
+    bc = 1.0 / (1.0 + b1 * ((omc / Om0) ** b2 - 1.0))
+
+    y = (1.0 + zeq) / (1.0 + zd)
+    Gy = y * (
+        -6.0 * jnp.sqrt(1.0 + y)
+        + (2.0 + 3.0 * y)
+        * jnp.log((jnp.sqrt(1.0 + y) + 1.0) / (jnp.sqrt(1.0 + y) - 1.0))
+    )
+
+    ab = 2.07 * keq * s * (1.0 + Rd) ** (-3.0 / 4.0) * Gy
+
+    f = 1.0 / (1.0 + (kh * s / 5.4) ** 4)
+
+    C = 14.2 / ac + 386.0 / (1.0 + 69.9 * q ** 1.08)
+    T0t = jnp.log(jnp.e + 1.8 * bc * q) / (
+        jnp.log(jnp.e + 1.8 * bc * q) + C * q * q
+    )
+
+    C1bc = 14.2 + 386.0 / (1.0 + 69.9 * q ** 1.08)
+    T0t1bc = jnp.log(jnp.e + 1.8 * bc * q) / (
+        jnp.log(jnp.e + 1.8 * bc * q) + C1bc * q * q
+    )
+    Tc = f * T0t1bc + (1.0 - f) * T0t
+
+    bb = (
+        0.5
+        + ombom0
+        + (3.0 - 2.0 * ombom0)
+        * jnp.sqrt((17.2 * om0h2) * (17.2 * om0h2) + 1.0)
+    )
+
+    bnode = 8.41 * om0h2 ** 0.435
+
+    st = s / (1.0 + (bnode / kh / s) * (bnode / kh / s) * (bnode / kh / s)) ** (
+        1.0 / 3.0
+    )
+
+    C11 = 14.2 + 386.0 / (1.0 + 69.9 * q ** 1.08)
+    T0t11 = jnp.log(jnp.e + 1.8 * q) / (jnp.log(jnp.e + 1.8 * q) + C11 * q * q)
+    Tb = (
+        T0t11 / (1.0 + (kh * s / 5.2) ** 2)
+        + ab / (1.0 + (bb / kh / s) ** 3) * jnp.exp(-((kh / ksilk) ** 1.4))
+    ) * jnp.sin(kh * st) / (kh * st)
+
+    return ombom0 * Tb + omc / Om0 * Tc
+
+
+# ---------------------------------------------------------------------------
+# sigma(R, z=0): RMS of mass within top-hat radius R, normalised to sigma8
+# ---------------------------------------------------------------------------
+
+
+def _tophat_window(x):
+    """W(x) = 3 (sin x - x cos x) / x^3, with a safe small-x expansion."""
+    small = x < 1.0e-3
+    # Taylor expansion to avoid 0/0 at x=0: W(x) ≈ 1 - x²/10 + x⁴/280
+    x2 = x * x
+    safe_small = 1.0 - x2 / 10.0 + x2 * x2 / 280.0
+    safe_large = 3.0 * (jnp.sin(x) - x * jnp.cos(x)) / jnp.where(small, 1.0, x ** 3)
+    return jnp.where(small, safe_small, safe_large)
+
+
+def _sigma2_unnormalised(R, h, Om0, Ob0, Tcmb0, ns,
+                         k_log_min=-5.0, k_log_max=3.0, nk=256):
+    """
+    sigma^2(R) at z=0 for an *unnormalised* power spectrum P(k) = k^ns T(k)^2.
+
+    The actual sigma^2 is then this value times the normalisation A fixed by
+    sigma(R=8) = sigma8.
+
+    Uses fixed log-k Gauss quadrature (trapezoidal in log-k) over a wide range.
+    """
+    ln_k = jnp.linspace(k_log_min * jnp.log(10.0),
+                        k_log_max * jnp.log(10.0), nk)
+    k = jnp.exp(ln_k)  # h/Mpc
+
+    Tk = transfer_eh98(k, h, Om0, Ob0, Tcmb0)
+    Pk_unnorm = k ** ns * Tk ** 2  # power spectrum modulo normalisation
+
+    # Broadcast: R is scalar or 1D; k is 1D
+    R = jnp.atleast_1d(R)
+    kR = k[None, :] * R[:, None]
+    W = _tophat_window(kR)
+
+    # integrand in log-k:  k^3 P(k) W^2(kR) / (2 pi^2)
+    integrand = k[None, :] ** 3 * Pk_unnorm[None, :] * W ** 2
+    integrand = integrand / (2.0 * jnp.pi ** 2)
+
+    sigma2 = jnp.trapezoid(integrand, ln_k, axis=-1)
+    if sigma2.shape == (1,):
+        return sigma2[0]
+    return sigma2
+
+
+def sigma_R(R, h, Om0, Ob0, Tcmb0, sigma8, ns,
+            k_log_min=-5.0, k_log_max=3.0, nk=256):
+    """sigma(R, z=0), normalised so sigma(R=8 Mpc/h) = sigma8."""
+    sigma2_unnorm = _sigma2_unnormalised(
+        R, h, Om0, Ob0, Tcmb0, ns,
+        k_log_min=k_log_min, k_log_max=k_log_max, nk=nk,
+    )
+    sigma2_8_unnorm = _sigma2_unnormalised(
+        jnp.array(8.0), h, Om0, Ob0, Tcmb0, ns,
+        k_log_min=k_log_min, k_log_max=k_log_max, nk=nk,
+    )
+    norm = sigma8 ** 2 / sigma2_8_unnorm
+    return jnp.sqrt(norm * sigma2_unnorm)
+
+
+# ---------------------------------------------------------------------------
+# Linear growth factor D(z), flat LCDM (no relspecies)
+# Integral form (Eisenstein & Hu 1999 Eq. 8 / Heath 1977), JAX-jittable.
+# ---------------------------------------------------------------------------
+
+
+def _E_lcdm(z, Om0, Ode0):
+    return jnp.sqrt(Om0 * (1.0 + z) ** 3 + Ode0)
+
+
+def _growth_unnormalised(z, Om0, Ode0, nz=512, z_max=1.0e4):
+    """
+    D_+(z) un-normalised, computed as
+
+        D_+(z) ∝ H(z)/H0 * integral from z to ∞ of (1+z') / E(z')^3 dz'
+
+    We integrate via change of variable u = ln(1+z') from z to ln(1+z_max).
+    """
+    z_arr = jnp.atleast_1d(z).astype(jnp.float64)
+
+    # Fixed grid in u = ln(1+z'), high upper limit so the integral converges
+    u_max = jnp.log(1.0 + z_max)
+    # Build a per-z grid: u goes from ln(1+z_i) to u_max in nz steps.
+    u_low = jnp.log(1.0 + z_arr)  # shape (M,)
+    u_grid = u_low[:, None] + (u_max - u_low)[:, None] * jnp.linspace(0.0, 1.0, nz)[None, :]
+    zp = jnp.exp(u_grid) - 1.0
+    Ep = _E_lcdm(zp, Om0, Ode0)
+    integrand = (1.0 + zp) ** 2 / Ep ** 3  # extra (1+zp) from du = dz'/(1+z')
+    integral = jnp.trapezoid(integrand, u_grid, axis=-1)
+
+    D = _E_lcdm(z_arr, Om0, Ode0) * integral
+    if z_arr.shape == ():
+        return D[0]
+    return D
+
+
+def growth_factor(z, Om0, Ode0, nz=512, z_max=1.0e4):
+    """D(z) / D(0), normalised growth factor for flat LCDM."""
+    D_z = _growth_unnormalised(z, Om0, Ode0, nz=nz, z_max=z_max)
+    D_0 = _growth_unnormalised(jnp.array(0.0), Om0, Ode0, nz=nz, z_max=z_max)
+    return D_z / D_0
+
+
+# ---------------------------------------------------------------------------
+# Einasto enclosed mass ratio (alpha = 0.18, dimensionless)
+#
+# For an Einasto profile ρ(r) = ρ_s exp(-2/α ((r/r_s)^α - 1)),
+#
+#     M(<r) ∝ γ_lower(3/α, 2/α (r/r_s)^α)        [unnormalised]
+#
+# Colossus calls this with c=1 (so r_s == R_200c of the reference halo) and
+# evaluates M(<r_s) / M(<r_s * c_array). The ratio simplifies to
+#
+#     M_ratio(c) = γ_lower(3/α, 2/α) / γ_lower(3/α, 2/α * c^α)
+#                = P(3/α, 2/α)        / P(3/α, 2/α * c^α)
+#
+# where P(s,x) = γ_lower(s,x)/Γ(s) is the regularised lower incomplete gamma
+# function. jax.scipy.special.gammainc(a, x) is exactly P(a, x).
+# ---------------------------------------------------------------------------
+
+
+_EINASTO_ALPHA = 0.18
+
+
+def einasto_mass_ratio(c, alpha=_EINASTO_ALPHA):
+    """M(<r_s) / M(<c*r_s) for an Einasto profile, dimensionless."""
+    s = 3.0 / alpha
+    x_inner = 2.0 / alpha
+    x_outer = 2.0 / alpha * c ** alpha
+    return gammainc(s, x_inner) / gammainc(s, x_outer)
+
+
+# ---------------------------------------------------------------------------
+# Concentration solver (vectorised port of modelLudlow16)
+# ---------------------------------------------------------------------------
+
+
+# Hard-coded constants from Ludlow+16
+_C_LUDLOW = 650.0
+_F_LUDLOW = 0.02
+_DELTA_COLLAPSE = 1.68647019984  # colossus constants.DELTA_COLLAPSE
+
+
+def _lagrangian_R(M, Om0, h):
+    """
+    Lagrangian radius of a halo of mass M.
+
+    M in Msun/h, returns R in Mpc/h.
+
+    R = (3 M / (4 π ρ_m,0))^(1/3) with ρ_m,0 in Msun*h^2 / Mpc^3.
+    """
+    # Critical density today: rho_crit = 2.77536627e11 Msun h^2 / Mpc^3
+    # (= 3 H0^2 / (8 pi G) with H0 in km/s/Mpc and standard G).
+    rho_crit_0 = 2.77536627e11
+    rho_m_0 = Om0 * rho_crit_0
+    return (3.0 * M / (4.0 * jnp.pi * rho_m_0)) ** (1.0 / 3.0)
+
+
+def _interp_zero(c_array, lhs_rhs_array):
+    """
+    Find c where lhs - rhs crosses zero, using linear interpolation.
+
+    Mirrors `np.interp(0.0, lhs_rhs, c_array)` from colossus, which requires
+    lhs_rhs to be monotonically increasing along c.
+    """
+    return jnp.interp(0.0, lhs_rhs_array, c_array)
+
+
+def ludlow16_concentration_jax(
+    M200c_Msun_per_h,
+    z,
+    h,
+    Om0,
+    Ob0,
+    Tcmb0,
+    sigma8,
+    ns,
+    Ode0=None,
+    c_array_size=200,
+    sigma_nk=256,
+    growth_nz=256,
+):
+    """
+    JAX-native port of `colossus.halo.concentration.modelLudlow16`.
+
+    Returns c200c for a single (M200c, z) pair. Assumes flat LCDM
+    (Ode0 = 1 - Om0 if not supplied) and ignores relativistic species,
+    matching the analytic LCDM branch in colossus.
+
+    Parameters
+    ----------
+    M200c_Msun_per_h : float or scalar jax array
+        Halo mass in Msun/h.
+    z : float
+        Redshift.
+    h, Om0, Ob0, Tcmb0, sigma8, ns : float
+        Cosmology parameters.
+    Ode0 : float, optional
+        Dark energy density today. Defaults to 1 - Om0 (flat universe).
+
+    Returns
+    -------
+    c200c : jnp.ndarray (scalar)
+    """
+    if Ode0 is None:
+        Ode0 = 1.0 - Om0
+
+    M = jnp.asarray(M200c_Msun_per_h, dtype=jnp.float64)
+    z = jnp.asarray(z, dtype=jnp.float64)
+
+    # Brute-force c grid (colossus uses np.logspace(0, 2, 200))
+    c_array = jnp.logspace(0.0, 2.0, c_array_size)
+
+    # M_ratio(c) — depends only on c, alpha (fixed=0.18). Independent of cosmo.
+    M_ratio = einasto_mass_ratio(c_array)
+
+    rho_f_rho_c = 200.0 * c_array ** 3 * M_ratio / _C_LUDLOW
+
+    # Formation redshift zf (closed-form LCDM expression from colossus).
+    t1 = (rho_f_rho_c * (Om0 * (1.0 + z) ** 3 + Ode0) - Ode0) / Om0
+    # Mask out c values where t1 <= 0 (no valid zf). For these we will
+    # let zf = 0 and rely on the lhs_rhs sign flip to keep them outside
+    # the interpolation root.
+    valid_c = t1 > 0.0
+    t1_safe = jnp.where(valid_c, t1, 1.0)
+    zf = t1_safe ** (1.0 / 3.0) - 1.0
+
+    # sigma^2 at f*M and at M (z=0 normalisation, growth factor applied later)
+    R_fM = _lagrangian_R(_F_LUDLOW * M, Om0, h)
+    R_M = _lagrangian_R(M, Om0, h)
+
+    sigma_fM = sigma_R(
+        R_fM, h, Om0, Ob0, Tcmb0, sigma8, ns, nk=sigma_nk
+    )
+    sigma_M = sigma_R(
+        R_M, h, Om0, Ob0, Tcmb0, sigma8, ns, nk=sigma_nk
+    )
+    sigma2_fM = sigma_fM ** 2
+    sigma2_M = sigma_M ** 2
+
+    # delta_z, delta_zf
+    D_z = growth_factor(z, Om0, Ode0, nz=growth_nz)
+    delta_z = _DELTA_COLLAPSE / D_z
+    D_zf = growth_factor(zf, Om0, Ode0, nz=growth_nz)
+    delta_zf = _DELTA_COLLAPSE / D_zf
+
+    # right-hand side of Ludlow16 Eq. 7
+    arg = (delta_zf - delta_z) / jnp.sqrt(
+        2.0 * (sigma2_fM - sigma2_M)
+    )
+    rhs = erfc(arg)
+
+    # Solve M_ratio - rhs == 0 along c. colossus trims c_array to entries with
+    # t1 > 0 then calls np.interp; the un-trimmed array must remain monotonic
+    # increasing in lhs_rhs for jnp.interp. Pin invalid entries (low c) below
+    # the lowest valid lhs_rhs so they sit at the bottom of the monotonic xp.
+    # Valid lhs_rhs ∈ [-1, 1] (both M_ratio, rhs ∈ [0, 1]); -10 is safely below.
+    lhs_rhs = M_ratio - rhs
+    lhs_rhs = jnp.where(valid_c, lhs_rhs, -10.0)
+
+    c200c = _interp_zero(c_array, lhs_rhs)
+    return c200c

--- a/docs/research/nfw_ludlow16_jax/science_check.py
+++ b/docs/research/nfw_ludlow16_jax/science_check.py
@@ -1,0 +1,459 @@
+"""
+End-to-end science validation of the JAX Ludlow16 prototype.
+
+The c200c relative error vs colossus is at most 7.5e-4 in isolation. This
+script propagates that into the *downstream* lensing quantities that drive
+likelihoods:
+
+  - kappa_s, scale_radius, radius_at_200      (from mcr_util helpers)
+  - convergence map of the resulting NFW profile, on a 2D grid
+  - deflection map of the resulting NFW profile, on a 2D grid
+  - same for the cNFW (core) helper
+
+It compares the *current* pipeline (colossus callback inside mcr_util) to a
+parallel pipeline that swaps in `ludlow16_concentration_jax`. Everything else
+about the helpers — the autogalaxy Planck15 cosmology used for rho_crit,
+Sigma_crit, kpc/arcsec — is identical between the two paths.
+
+Run:
+    NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \
+        JAX_ENABLE_X64=1 python docs/research/nfw_ludlow16_jax/science_check.py
+"""
+
+import os
+import sys
+
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+os.environ.setdefault("NUMBA_CACHE_DIR", "/tmp/numba_cache")
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/matplotlib")
+
+import numpy as np
+import jax
+jax.config.update("jax_enable_x64", True)
+
+import autogalaxy as ag
+from autogalaxy.profiles.mass.dark import mcr_util
+from autogalaxy.cosmology.model import Planck15
+
+sys.path.insert(0, os.path.dirname(__file__))
+from ludlow16_jax import ludlow16_concentration_jax  # noqa: E402
+
+
+# Colossus 'planck15' preset — what _ludlow16_cosmology_callback uses
+# internally for the concentration. autogalaxy's Planck15 (Om0=0.3075) is used
+# for everything else; we match that pattern.
+COLOSSUS_PLANCK15 = dict(
+    h=0.6774,
+    Om0=0.3089,
+    Ob0=0.0486,
+    Tcmb0=2.7255,
+    sigma8=0.8159,
+    ns=0.9667,
+)
+
+
+# ---------------------------------------------------------------------------
+# JAX-native replacement for _ludlow16_cosmology_callback
+# ---------------------------------------------------------------------------
+
+
+def ludlow16_cosmology_jax_native(mass_at_200, redshift_object, redshift_source):
+    """
+    Drop-in replacement for `mcr_util._ludlow16_cosmology_callback`.
+
+    Same four returns as the current callback, but with the colossus
+    concentration call replaced by the JAX-native prototype. The other three
+    values flow through autogalaxy's Planck15 unchanged.
+    """
+    cosmology = Planck15()
+    h = COLOSSUS_PLANCK15["h"]
+
+    # JAX path: convert M_sun → M_sun/h, call the JAX concentration
+    concentration = float(
+        ludlow16_concentration_jax(
+            mass_at_200 * h,
+            redshift_object,
+            **COLOSSUS_PLANCK15,
+        )
+    )
+
+    cosmic_average_density = cosmology.critical_density(redshift_object, xp=np)
+    critical_surface_density = (
+        cosmology.critical_surface_density_between_redshifts_solar_mass_per_kpc2_from(
+            redshift_0=redshift_object,
+            redshift_1=redshift_source,
+            xp=np,
+        )
+    )
+    kpc_per_arcsec = cosmology.kpc_per_arcsec_from(
+        redshift=redshift_object, xp=np
+    )
+
+    return (
+        np.float64(concentration),
+        np.float64(cosmic_average_density),
+        np.float64(critical_surface_density),
+        np.float64(kpc_per_arcsec),
+    )
+
+
+def kappa_s_scale_radius_ludlow_jax(
+    mass_at_200, scatter_sigma, redshift_object, redshift_source
+):
+    """
+    Mirror of `mcr_util.kappa_s_and_scale_radius_for_ludlow` numpy branch
+    but with the JAX concentration replacement.
+    """
+    (
+        concentration,
+        cosmic_average_density,
+        critical_surface_density,
+        kpc_per_arcsec,
+    ) = ludlow16_cosmology_jax_native(
+        mass_at_200, redshift_object, redshift_source
+    )
+
+    concentration = 10.0 ** (np.log10(concentration) + scatter_sigma * 0.15)
+
+    radius_at_200 = (
+        mass_at_200 / (200.0 * cosmic_average_density * (4.0 * np.pi / 3.0))
+    ) ** (1.0 / 3.0)
+
+    de_c = (
+        200.0
+        / 3.0
+        * (
+            concentration ** 3
+            / (np.log(1.0 + concentration) - concentration / (1.0 + concentration))
+        )
+    )
+
+    scale_radius_kpc = radius_at_200 / concentration
+    rho_s = cosmic_average_density * de_c
+    kappa_s = rho_s * scale_radius_kpc / critical_surface_density
+    scale_radius = scale_radius_kpc / kpc_per_arcsec
+
+    return kappa_s, scale_radius, radius_at_200
+
+
+def kappa_s_scale_radius_core_radius_ludlow_jax(
+    mass_at_200, scatter_sigma, f_c, redshift_object, redshift_source
+):
+    """Mirror of `mcr_util.kappa_s_scale_radius_and_core_radius_for_ludlow`."""
+    (
+        concentration,
+        cosmic_average_density,
+        critical_surface_density,
+        kpc_per_arcsec,
+    ) = ludlow16_cosmology_jax_native(
+        mass_at_200, redshift_object, redshift_source
+    )
+
+    concentration = 10.0 ** (np.log10(concentration) + scatter_sigma * 0.15)
+
+    radius_at_200 = (
+        mass_at_200 / (200.0 * cosmic_average_density * (4.0 * np.pi / 3.0))
+    ) ** (1.0 / 3.0)
+
+    mcr_penarrubia = (
+        f_c ** 2 * np.log(1 + concentration / f_c)
+        + (1 - 2 * f_c) * np.log(1 + concentration)
+    ) / (1 + f_c) ** 2 - concentration / ((1 + concentration) * (1 - f_c))
+
+    scale_radius_kpc = radius_at_200 / concentration
+    rho_0 = mass_at_200 / (4 * np.pi * scale_radius_kpc ** 3 * mcr_penarrubia)
+    kappa_s = rho_0 * scale_radius_kpc / critical_surface_density
+    scale_radius = scale_radius_kpc / kpc_per_arcsec
+    core_radius = f_c * scale_radius
+
+    return kappa_s, scale_radius, core_radius, radius_at_200
+
+
+# ---------------------------------------------------------------------------
+# Check 1: helper outputs (kappa_s, scale_radius, radius_at_200) across grid
+# ---------------------------------------------------------------------------
+
+
+def helper_grid_check():
+    print("=" * 86)
+    print("Check 1: NFWMCRLudlow helper outputs — kappa_s, scale_radius, "
+          "radius_at_200")
+    print("(mass M_200 in Msun physical; scatter_sigma sweep too)")
+    print("=" * 86)
+
+    log_M_grid = [10.5, 11.5, 12.5, 13.5]
+    z_obj_grid = [0.1, 0.3, 0.5, 1.0, 1.5]
+    z_src_grid = [1.0, 1.5, 2.5]
+    scatter_grid = [-1.0, 0.0, 1.0]
+
+    print(f"{'log M':>8} {'z_obj':>6} {'z_src':>6} {'σ_scat':>7} "
+          f"{'kappa_s':>10} {'sc.rad':>10} {'r_200':>10} "
+          f"{'Δκ/κ':>10} {'Δs/s':>10} {'Δr/r':>10}")
+    print("-" * 110)
+
+    max_rel = {"kappa_s": 0.0, "scale_radius": 0.0, "radius_at_200": 0.0}
+
+    for log_M in log_M_grid:
+        for z_obj in z_obj_grid:
+            for z_src in z_src_grid:
+                if z_src <= z_obj:
+                    continue
+                for scatter in scatter_grid:
+                    M = 10.0 ** log_M
+                    k_col, s_col, r_col = (
+                        mcr_util.kappa_s_and_scale_radius_for_ludlow(
+                            M, scatter, z_obj, z_src
+                        )
+                    )
+                    k_jax, s_jax, r_jax = kappa_s_scale_radius_ludlow_jax(
+                        M, scatter, z_obj, z_src
+                    )
+                    rk = abs(k_jax - k_col) / abs(k_col)
+                    rs = abs(s_jax - s_col) / abs(s_col)
+                    rr = abs(r_jax - r_col) / abs(r_col)
+                    max_rel["kappa_s"] = max(max_rel["kappa_s"], rk)
+                    max_rel["scale_radius"] = max(max_rel["scale_radius"], rs)
+                    max_rel["radius_at_200"] = max(max_rel["radius_at_200"], rr)
+                    print(
+                        f"{log_M:8.2f} {z_obj:6.2f} {z_src:6.2f} {scatter:7.1f} "
+                        f"{k_col:10.4e} {s_col:10.4e} {r_col:10.4e} "
+                        f"{rk:10.2e} {rs:10.2e} {rr:10.2e}"
+                    )
+
+    print("-" * 110)
+    print("Max relative errors across the helper grid:")
+    for k, v in max_rel.items():
+        print(f"  {k:>16s}: {v:.3e}")
+    print()
+    return max_rel
+
+
+# ---------------------------------------------------------------------------
+# Check 2: convergence + deflection maps for representative NFW model
+# ---------------------------------------------------------------------------
+
+
+def lensing_map_check(label, build_profile_col, build_profile_jax,
+                     case_descs, grid_shape=(50, 50), pixel_scales=0.1):
+    print("=" * 86)
+    print(f"Check 2 ({label}): convergence + deflection maps on a 2D grid")
+    print(f"(grid {grid_shape[0]}x{grid_shape[1]} at {pixel_scales} arcsec/pix)")
+    print("=" * 86)
+
+    grid = ag.Grid2D.uniform(shape_native=grid_shape, pixel_scales=pixel_scales)
+
+    print(f"{'case':>32} "
+          f"{'|Δκ|_max':>10} {'|Δκ/κ|_max':>12} {'|Δκ/κ|_med':>12} "
+          f"{'|Δα|_max':>10} {'|Δα/α|_max':>12} {'|Δα/α|_med':>12}")
+    print("-" * 110)
+
+    overall = {
+        "abs_kappa": 0.0,
+        "rel_kappa_max": 0.0,
+        "rel_kappa_med": 0.0,
+        "abs_defl": 0.0,
+        "rel_defl_max": 0.0,
+        "rel_defl_med": 0.0,
+    }
+
+    for desc, params in case_descs:
+        prof_col = build_profile_col(**params)
+        prof_jax = build_profile_jax(**params)
+
+        k_col = np.asarray(prof_col.convergence_2d_from(grid=grid))
+        k_jax = np.asarray(prof_jax.convergence_2d_from(grid=grid))
+        d_col = np.asarray(prof_col.deflections_yx_2d_from(grid=grid))
+        d_jax = np.asarray(prof_jax.deflections_yx_2d_from(grid=grid))
+
+        abs_k = np.abs(k_jax - k_col)
+        rel_k = abs_k / np.maximum(np.abs(k_col), 1e-30)
+        # deflections are (y, x) vectors; use magnitude
+        d_col_mag = np.linalg.norm(d_col.reshape(-1, 2), axis=-1)
+        d_jax_mag = np.linalg.norm(d_jax.reshape(-1, 2), axis=-1)
+        abs_d = np.abs(d_jax_mag - d_col_mag)
+        rel_d = abs_d / np.maximum(np.abs(d_col_mag), 1e-30)
+
+        overall["abs_kappa"] = max(overall["abs_kappa"], abs_k.max())
+        overall["rel_kappa_max"] = max(overall["rel_kappa_max"], rel_k.max())
+        overall["rel_kappa_med"] = max(overall["rel_kappa_med"], np.median(rel_k))
+        overall["abs_defl"] = max(overall["abs_defl"], abs_d.max())
+        overall["rel_defl_max"] = max(overall["rel_defl_max"], rel_d.max())
+        overall["rel_defl_med"] = max(overall["rel_defl_med"], np.median(rel_d))
+
+        print(
+            f"{desc:>32} "
+            f"{abs_k.max():10.2e} {rel_k.max():12.2e} {np.median(rel_k):12.2e} "
+            f"{abs_d.max():10.2e} {rel_d.max():12.2e} {np.median(rel_d):12.2e}"
+        )
+
+    print("-" * 110)
+    print("Worst across cases:")
+    for k, v in overall.items():
+        print(f"  {k:>16s}: {v:.3e}")
+    print()
+    return overall
+
+
+# ---------------------------------------------------------------------------
+# Profile builders — we instantiate the existing autogalaxy profiles for the
+# colossus path. For the JAX path we instantiate the same profile class but
+# monkey-patch the helper to call our JAX replacement.
+# ---------------------------------------------------------------------------
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def patch_mcr_util_with_jax():
+    """Within this context, mcr_util.kappa_s_and_scale_radius_for_ludlow and
+    mcr_util.kappa_s_scale_radius_and_core_radius_for_ludlow use the JAX
+    concentration instead of the colossus callback."""
+    orig_ludlow = mcr_util.kappa_s_and_scale_radius_for_ludlow
+    orig_cnfw = mcr_util.kappa_s_scale_radius_and_core_radius_for_ludlow
+    mcr_util.kappa_s_and_scale_radius_for_ludlow = (
+        kappa_s_scale_radius_ludlow_jax
+    )
+    mcr_util.kappa_s_scale_radius_and_core_radius_for_ludlow = (
+        kappa_s_scale_radius_core_radius_ludlow_jax
+    )
+    try:
+        yield
+    finally:
+        mcr_util.kappa_s_and_scale_radius_for_ludlow = orig_ludlow
+        mcr_util.kappa_s_scale_radius_and_core_radius_for_ludlow = orig_cnfw
+
+
+def build_nfwmcrludlow_col(M, z_obj, z_src, scatter):
+    return ag.mp.NFWMCRScatterLudlowSph(
+        centre=(0.0, 0.0),
+        mass_at_200=M,
+        scatter_sigma=scatter,
+        redshift_object=z_obj,
+        redshift_source=z_src,
+    )
+
+
+def build_nfwmcrludlow_jax(M, z_obj, z_src, scatter):
+    with patch_mcr_util_with_jax():
+        return ag.mp.NFWMCRScatterLudlowSph(
+            centre=(0.0, 0.0),
+            mass_at_200=M,
+            scatter_sigma=scatter,
+            redshift_object=z_obj,
+            redshift_source=z_src,
+        )
+
+
+def build_cnfwmcrludlow_col(M, z_obj, z_src, scatter, f_c):
+    return ag.mp.cNFWMCRScatterLudlowSph(
+        centre=(0.0, 0.0),
+        mass_at_200=M,
+        scatter_sigma=scatter,
+        f_c=f_c,
+        redshift_object=z_obj,
+        redshift_source=z_src,
+    )
+
+
+def build_cnfwmcrludlow_jax(M, z_obj, z_src, scatter, f_c):
+    with patch_mcr_util_with_jax():
+        return ag.mp.cNFWMCRScatterLudlowSph(
+            centre=(0.0, 0.0),
+            mass_at_200=M,
+            scatter_sigma=scatter,
+            f_c=f_c,
+            redshift_object=z_obj,
+            redshift_source=z_src,
+        )
+
+
+def main():
+    helper_grid_check()
+
+    # Representative NFW lensing cases (cluster, group, galaxy, dwarf)
+    nfw_cases = [
+        ("M=5e14 cluster, z=(0.3,1.5), σ=0",
+         dict(M=5.0e14, z_obj=0.3, z_src=1.5, scatter=0.0)),
+        ("M=1e13 group,  z=(0.5,2.0), σ=0",
+         dict(M=1.0e13, z_obj=0.5, z_src=2.0, scatter=0.0)),
+        ("M=1e12 galaxy, z=(0.2,1.0), σ=0",
+         dict(M=1.0e12, z_obj=0.2, z_src=1.0, scatter=0.0)),
+        ("M=1e11 dwarf,  z=(0.1,1.0), σ=0",
+         dict(M=1.0e11, z_obj=0.1, z_src=1.0, scatter=0.0)),
+        ("M=1e12, σ=+1.5 (high scatter)",
+         dict(M=1.0e12, z_obj=0.3, z_src=2.0, scatter=1.5)),
+        ("M=1e12, σ=-1.5 (low scatter)",
+         dict(M=1.0e12, z_obj=0.3, z_src=2.0, scatter=-1.5)),
+    ]
+    lensing_map_check(
+        "NFWMCRScatterLudlow", build_nfwmcrludlow_col,
+        build_nfwmcrludlow_jax, nfw_cases,
+    )
+
+    # cNFW: f_c values where the Penarrubia mcr is physical (positive)
+    # and grids large enough to sample the convergence outside the core.
+    cnfw_cases = [
+        ("M=1e13, f_c=0.05, σ=0  (grid 50x50 @ 0.5\")",
+         dict(M=1.0e13, z_obj=0.3, z_src=1.5, scatter=0.0, f_c=0.05),
+         (50, 50), 0.5),
+        ("M=1e12, f_c=0.05, σ=0  (grid 50x50 @ 0.1\")",
+         dict(M=1.0e12, z_obj=0.3, z_src=1.5, scatter=0.0, f_c=0.05),
+         (50, 50), 0.1),
+        ("M=1e12, f_c=0.10, σ=+1.0 (grid 50x50 @ 0.1\")",
+         dict(M=1.0e12, z_obj=0.5, z_src=2.0, scatter=1.0, f_c=0.10),
+         (50, 50), 0.1),
+    ]
+
+    # need per-case grid override → small helper inline
+    print("=" * 86)
+    print("Check 2 (cNFWMCRScatterLudlow): convergence + deflection maps")
+    print("=" * 86)
+    print(f"{'case':>45} "
+          f"{'|Δκ|_max':>10} {'|Δκ/κ|_max':>12} {'|Δκ/κ|_med':>12} "
+          f"{'|Δα|_max':>10} {'|Δα/α|_max':>12} {'|Δα/α|_med':>12}")
+    print("-" * 130)
+
+    overall = {"abs_kappa": 0.0, "rel_kappa_max": 0.0, "rel_kappa_med": 0.0,
+               "abs_defl": 0.0, "rel_defl_max": 0.0, "rel_defl_med": 0.0}
+    for desc, params, gshape, gscale in cnfw_cases:
+        grid = ag.Grid2D.uniform(shape_native=gshape, pixel_scales=gscale)
+        p_col = build_cnfwmcrludlow_col(**params)
+        p_jax = build_cnfwmcrludlow_jax(**params)
+        k_col = np.asarray(p_col.convergence_2d_from(grid=grid))
+        k_jax = np.asarray(p_jax.convergence_2d_from(grid=grid))
+        d_col = np.asarray(p_col.deflections_yx_2d_from(grid=grid))
+        d_jax = np.asarray(p_jax.deflections_yx_2d_from(grid=grid))
+
+        # mask out nans (cNFW formulas hit invalid-sqrt branches at theta≈radius)
+        valid = ~(np.isnan(k_col) | np.isnan(k_jax))
+        abs_k = np.abs(k_jax[valid] - k_col[valid])
+        rel_k = abs_k / np.maximum(np.abs(k_col[valid]), 1e-30)
+        d_col_m = np.linalg.norm(d_col.reshape(-1, 2), axis=-1)
+        d_jax_m = np.linalg.norm(d_jax.reshape(-1, 2), axis=-1)
+        valid_d = ~(np.isnan(d_col_m) | np.isnan(d_jax_m))
+        abs_d = np.abs(d_jax_m[valid_d] - d_col_m[valid_d])
+        rel_d = abs_d / np.maximum(np.abs(d_col_m[valid_d]), 1e-30)
+
+        overall["abs_kappa"] = max(overall["abs_kappa"], abs_k.max() if abs_k.size else 0)
+        overall["rel_kappa_max"] = max(overall["rel_kappa_max"], rel_k.max() if rel_k.size else 0)
+        overall["rel_kappa_med"] = max(overall["rel_kappa_med"], np.median(rel_k) if rel_k.size else 0)
+        overall["abs_defl"] = max(overall["abs_defl"], abs_d.max() if abs_d.size else 0)
+        overall["rel_defl_max"] = max(overall["rel_defl_max"], rel_d.max() if rel_d.size else 0)
+        overall["rel_defl_med"] = max(overall["rel_defl_med"], np.median(rel_d) if rel_d.size else 0)
+
+        print(f"{desc:>45} "
+              f"{(abs_k.max() if abs_k.size else 0):10.2e} "
+              f"{(rel_k.max() if rel_k.size else 0):12.2e} "
+              f"{(np.median(rel_k) if rel_k.size else 0):12.2e} "
+              f"{(abs_d.max() if abs_d.size else 0):10.2e} "
+              f"{(rel_d.max() if rel_d.size else 0):12.2e} "
+              f"{(np.median(rel_d) if rel_d.size else 0):12.2e}")
+    print("-" * 130)
+    print("Worst across cNFW cases:")
+    for k, v in overall.items():
+        print(f"  {k:>16s}: {v:.3e}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/nfw_ludlow16_jax/tune.py
+++ b/docs/research/nfw_ludlow16_jax/tune.py
@@ -1,0 +1,58 @@
+"""
+Sweep nk (σ(R) k-grid) and nz (growth-factor z-grid) to find the smallest
+grids that hold ≤ 0.1% relative error vs colossus.
+"""
+
+import os
+import time
+import numpy as np
+
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import jax
+jax.config.update("jax_enable_x64", True)
+
+from colossus.cosmology import cosmology as col_cosmology
+from colossus.halo.concentration import concentration as col_concentration
+
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+from ludlow16_jax import ludlow16_concentration_jax  # noqa: E402
+
+
+PLANCK15 = dict(
+    h=0.6774, Om0=0.3089, Ob0=0.0486, Tcmb0=2.7255,
+    sigma8=0.8159, ns=0.9667,
+)
+
+
+def max_rel_err(nk, nz):
+    col_cosmology.setCosmology("planck15")
+    fn = jax.jit(lambda M, z: ludlow16_concentration_jax(
+        M, z, **PLANCK15, sigma_nk=nk, growth_nz=nz,
+    ))
+    _ = fn(1.0e12, 0.5).block_until_ready()  # warm up
+
+    max_err = 0.0
+    for log_M in np.linspace(10.0, 14.0, 9):
+        for z in np.linspace(0.1, 2.5, 7):
+            M = 10.0 ** log_M
+            c_col = float(col_concentration(M, "200c", z, model="ludlow16"))
+            c_jax = float(fn(M, z))
+            err = abs(c_jax - c_col) / c_col
+            max_err = max(max_err, err)
+    # timing
+    n_iter = 30
+    t0 = time.perf_counter()
+    for _ in range(n_iter):
+        _ = fn(1.0e12, 0.5).block_until_ready()
+    t = (time.perf_counter() - t0) / n_iter
+    return max_err, t
+
+
+print(f"{'nk':>6} {'nz':>6} {'max_rel_err':>14} {'wall (ms)':>10}")
+print("-" * 42)
+for nk in [256, 512, 1024, 2048, 4096]:
+    for nz in [128, 256, 512]:
+        e, t = max_rel_err(nk, nz)
+        print(f"{nk:>6d} {nz:>6d} {e:>14.3e} {t*1e3:>10.3f}")

--- a/docs/research/nfw_ludlow16_jax/validate.py
+++ b/docs/research/nfw_ludlow16_jax/validate.py
@@ -1,0 +1,108 @@
+"""
+Validate the JAX prototype `ludlow16_concentration_jax` against colossus'
+`modelLudlow16` over the strong-lensing parameter regime.
+
+Run with:
+    NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \
+        python docs/research/nfw_ludlow16_jax/validate.py
+"""
+
+import os
+import time
+import numpy as np
+
+# Force float64 in JAX
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+
+from colossus.cosmology import cosmology as col_cosmology
+from colossus.halo.concentration import concentration as col_concentration
+
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+from ludlow16_jax import ludlow16_concentration_jax  # noqa: E402
+
+
+# Planck15 parameters (matches colossus' built-in 'planck15')
+PLANCK15 = dict(
+    h=0.6774,
+    Om0=0.3089,
+    Ob0=0.0486,
+    Tcmb0=2.7255,
+    sigma8=0.8159,
+    ns=0.9667,
+)
+
+
+def colossus_c200c(M_Msun_per_h, z):
+    """Reference concentration via colossus."""
+    col_cosmology.setCosmology("planck15")
+    c = col_concentration(M_Msun_per_h, "200c", z, model="ludlow16")
+    return float(c)
+
+
+def main():
+    col_cosmology.setCosmology("planck15")
+
+    # Grid: log M_200c in Msun/h ∈ [10, 14], z ∈ [0.1, 2.5]
+    log_M_grid = np.linspace(10.0, 14.0, 9)
+    z_grid = np.linspace(0.1, 2.5, 7)
+
+    print("=" * 72)
+    print("Ludlow16 concentration: JAX prototype vs colossus")
+    print("(M in Msun/h, c200c dimensionless)")
+    print("=" * 72)
+    print(f"{'log M':>8} {'z':>6} {'c_colossus':>12} {'c_jax':>12} "
+          f"{'rel_err':>10}")
+    print("-" * 72)
+
+    max_rel = 0.0
+    rows = []
+    for log_M in log_M_grid:
+        for z in z_grid:
+            M = 10.0 ** log_M
+            c_col = colossus_c200c(M, z)
+            c_jax = float(
+                ludlow16_concentration_jax(M, z, **PLANCK15)
+            )
+            rel = abs(c_jax - c_col) / c_col
+            max_rel = max(max_rel, rel)
+            rows.append((log_M, z, c_col, c_jax, rel))
+            print(f"{log_M:8.2f} {z:6.2f} {c_col:12.4f} {c_jax:12.4f} "
+                  f"{rel:10.2e}")
+
+    print("-" * 72)
+    print(f"Max relative error across grid: {max_rel:.3e}")
+    print()
+
+    # Speed comparison (cached compilation)
+    jit_fn = jax.jit(
+        lambda M, z: ludlow16_concentration_jax(M, z, **PLANCK15)
+    )
+    # warm up
+    _ = jit_fn(1.0e12, 0.5).block_until_ready()
+
+    M_test, z_test = 1.0e12, 0.5
+    n_iter = 50
+
+    t0 = time.perf_counter()
+    for _ in range(n_iter):
+        _ = colossus_c200c(M_test, z_test)
+    t_col = (time.perf_counter() - t0) / n_iter
+
+    t0 = time.perf_counter()
+    for _ in range(n_iter):
+        _ = jit_fn(M_test, z_test).block_until_ready()
+    t_jax = (time.perf_counter() - t0) / n_iter
+
+    print(f"Single-call wall time at (M=1e12, z=0.5):")
+    print(f"  colossus      : {t_col*1e3:.3f} ms")
+    print(f"  jax (post-jit): {t_jax*1e3:.3f} ms")
+    print(f"  speedup       : {t_col / t_jax:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/research/nfw_ludlow16_jax_assessment.md
+++ b/docs/research/nfw_ludlow16_jax_assessment.md
@@ -1,0 +1,311 @@
+# JAX-native replacement for the Ludlow16 concentration `pure_callback`
+
+**Issue:** [Jammy2211/PyAutoGalaxy#397](https://github.com/PyAutoLabs/PyAutoGalaxy/issues/397)
+**Date:** 2026-05-14
+**Status:** Phase 1 — feasibility report. Approach A confirmed viable; recommendation is to proceed to Phase 2 implementation.
+
+## TL;DR
+
+A fully JAX-native port of `colossus.halo.concentration.modelLudlow16`
+(`Approach A` in the original plan) is **feasible, faithful, and modestly
+faster than colossus itself**. It removes the `jax.pure_callback` entirely.
+The full prototype is ~330 lines of straight-line JAX, contained in one file,
+with no new runtime dependencies.
+
+| Metric | colossus callback | JAX (Approach A) |
+|---|---|---|
+| Max relative error in c200c (log M ∈ [10,14], z ∈ [0.1,2.5]) | reference | **7.5 × 10⁻⁴** |
+| Single-call wall time (post-JIT, CPU, float64) | 0.83 ms | **0.69 ms** (1.2× faster) |
+| Batch of 32 calls (vmap) | 14.46 ms (serial) | **11.24 ms** (1.29× faster) |
+| `jax.grad` through it | not possible | **works**, matches FD to 7 × 10⁻⁴ |
+| `jax.jit` of a whole likelihood that calls it | breaks at callback boundary | **JITs end-to-end** |
+| Runtime colossus dependency | required | **not required** |
+| Lines of code | n/a | ~330 (one file) |
+
+Approaches B (lookup table) and C (analytic fit) were not prototyped — A's
+numbers landed comfortably inside the accuracy budget and the code is simple
+enough that the engineering trade-off favours it cleanly.
+
+## Why the callback exists
+
+`mcr_util.py::_ludlow16_cosmology_callback` returns four scalars per call:
+- `concentration` — Ludlow+16 c200c from colossus
+- `cosmic_average_density` — ρ_crit(z) in Msun/kpc³
+- `critical_surface_density` — Σ_crit between lens and source in Msun/kpc²
+- `kpc_per_arcsec` — angular-diameter scale at the lens
+
+Of these four, only `concentration` is JAX-hostile. The other three already
+flow through `autogalaxy.cosmology.model.Planck15`, which is **fully JAX-native**
+via the `xp` parameter pattern (`xp=jnp` enabled). The current `pure_callback`
+bundles the JAX-safe three with the one JAX-hostile call. So the actual
+porting target is just the concentration computation.
+
+## Dependency audit of `colossus.halo.concentration.modelLudlow16`
+
+| colossus dependency | What it computes | JAX porting difficulty |
+|---|---|---|
+| `cosmology.sigma(R, z=0)` | RMS mass variance σ(R) | **Hard** (requires P(k) — Eisenstein-Hu '98 transfer + window-function integral). ~100 lines. |
+| `cosmology.growthFactor(z)` | linear growth D(z) | Easy — flat ΛCDM has a 1-D quadrature (Heath '77 / Eisenstein-Hu '99 Eq. 8). |
+| `peaks.lagrangianR(M)` | `(3M / 4π ρ_m,0)^(1/3)` | Trivial. |
+| `profile_einasto.EinastoProfile.enclosedMassInner` | Einasto M(<r) at α=0.18 | Easy — closed form via `jax.scipy.special.gammainc`. The full `M_ratio(c)` reduces to `P(3/α, 2/α) / P(3/α, (2/α) c^α)` — independent of cosmology and mass. |
+| `scipy.special.erfc` | erfc | Trivial — `jax.scipy.special.erfc`. |
+| 200-point `c_array` brute-force + `np.interp` per mass | root finder along c | Trivial — `jnp.interp`, single call. |
+
+The genuine work is just the σ(R) integral. Everything else is mechanical.
+
+## Approach A — the prototype
+
+Files in [`nfw_ludlow16_jax/`](nfw_ludlow16_jax/):
+- [`ludlow16_jax.py`](nfw_ludlow16_jax/ludlow16_jax.py) — the implementation (~330 lines, one file).
+- [`validate.py`](nfw_ludlow16_jax/validate.py) — accuracy comparison against the colossus callback over the lensing grid.
+- [`bench.py`](nfw_ludlow16_jax/bench.py) — grad correctness + vmap timing.
+- [`tune.py`](nfw_ludlow16_jax/tune.py) — sweep over `nk` (σ(R) k-grid) and `nz` (growth-factor z-grid).
+
+### Algorithm pieces
+
+1. **`transfer_eh98(k, h, Om0, Ob0, Tcmb0)`** — direct JAX port of
+   `colossus.cosmology.power_spectrum.modelEisenstein98`. Pure numpy in
+   colossus, ~100 lines of arithmetic. Translates verbatim to `jnp` (only
+   `np.sqrt`, `np.log`, `np.exp`, `np.sin`, `np.cos` used — all have JAX
+   equivalents). No control flow, no scipy calls.
+2. **`sigma_R(R, h, Om0, Ob0, Tcmb0, sigma8, ns)`** — top-hat σ(R, z=0)
+   normalised to σ₈. Implemented as a fixed log-k trapezoidal quadrature
+   over k ∈ [10⁻⁵, 10³] h/Mpc with `nk=256` points. The σ₈ normalisation is
+   computed once per call as σ_unnorm(R=8) and folded in. With `_tophat_window`
+   using a Taylor expansion near `x=0` to avoid the 0/0 in `3(sin x − x cos x)/x³`.
+3. **`growth_factor(z, Om0, Ode0)`** — D(z)/D(0) for flat ΛCDM via the
+   integral form (Heath '77). Change-of-variable to `u = ln(1+z)` and
+   trapezoidal quadrature with `nz=256` points from `u=ln(1+z)` to
+   `u=ln(1+10⁴)`. Computes per-z grids inside JIT via broadcasting (each input
+   z gets its own integration range to `u_max`).
+4. **`einasto_mass_ratio(c, alpha=0.18)`** — `gammainc(3/α, 2/α) / gammainc(3/α, (2/α) c^α)`.
+   Independent of cosmology and halo mass — a fixed 1-D function of c only.
+5. **`_lagrangian_R(M, Om0, h)`** — `(3M / 4π ρ_m,0)^(1/3)` using
+   ρ_crit,0 = 2.77537 × 10¹¹ Msun h²/Mpc³.
+6. **`ludlow16_concentration_jax(...)`** — assembles the pieces. Mirrors
+   `modelLudlow16` line-for-line:
+   - Build `c_array = jnp.logspace(0, 2, 200)`.
+   - Compute `M_ratio(c_array)`.
+   - Compute `t1(c_array, z, Om0, Ode0)`; mask `t1 ≤ 0` entries as invalid.
+   - Compute `zf(c_array)` from valid `t1`.
+   - Compute σ²(R(fM)) and σ²(R(M)) — two `sigma_R` calls.
+   - Compute δ_z = δ_c/D(z), δ_zf = δ_c/D(zf).
+   - Compute `rhs = erfc((δ_zf − δ_z) / √(2(σ²_fM − σ²_M)))`.
+   - `lhs_rhs = M_ratio − rhs`; set invalid entries to a sentinel (−10) so
+     `jnp.interp(0, lhs_rhs, c_array)` finds the root through the
+     monotonically-increasing valid region.
+
+### Known fix: monotonicity of `lhs_rhs`
+
+A first attempt used `jnp.where(valid_c, lhs_rhs, jnp.inf)` to mask out
+`t1 ≤ 0` entries. That broke `jnp.interp` at low z / low M: invalid entries
+sit at the low-c end (where `t1 < 0`), and pushing them to `+inf` makes the
+xp array non-monotonic, so `jnp.interp(0, ...)` clamped to the boundary
+value c=1. Replacing the sentinel with `-10.0` (safely below any valid
+`lhs_rhs ∈ [−1, 1]`) restores monotonicity and the correct root.
+
+### Accuracy
+
+On a 9 × 7 grid of (log M, z) covering the lensing regime
+(log M ∈ [10, 14] in Msun/h, z ∈ [0.1, 2.5]):
+
+```
+Max relative error across grid: 7.5 × 10⁻⁴
+```
+
+Most cells are at 10⁻⁴ or better. The largest errors (~7 × 10⁻⁴) are at
+the high-z corner — likely the σ(R) integration is the dominant source.
+None of this matters for any downstream science use: c200c is an empirical
+calibration with intrinsic scatter ~0.15 dex, so sub-percent precision
+against colossus is overkill.
+
+The grid sweep over `(nk, nz)` shows the error floor at ~7 × 10⁻⁴ is
+**structural** (probably the EH98 fit vs colossus' refined matter power
+spectrum), not a discretisation effect: increasing `nk` beyond 256 or `nz`
+beyond 256 makes no measurable improvement.
+
+```
+    nk     nz    max_rel_err  wall (ms)
+   256    128      3.20e-03      0.47
+   256    256      7.50e-04      0.49
+   256    512      6.99e-04      0.86
+   512    128      3.21e-03      0.45
+   512    256      7.52e-04      0.58
+   ...    ...      ...           ...
+  4096    512      6.98e-04      1.81
+```
+
+Defaults are set to `nk=256, nz=256` — the sweet spot.
+
+### Speed
+
+Single-call (CPU, float64, post-JIT compile):
+
+| | ms |
+|---|---|
+| colossus | 0.83 |
+| JAX (Approach A) | **0.69** |
+
+JIT compile time is ~0.7 s (one-time per shape). After compilation the JAX
+version is faster than the colossus callback. The win comes mostly from
+removing the Python overhead colossus carries (mass-definition logic, model
+dispatch, EinastoProfile construction, etc.) — the actual arithmetic is
+about the same.
+
+Batch of 32 concentration calls via `jax.vmap`:
+
+| | ms |
+|---|---|
+| colossus (serial loop) | 14.46 |
+| JAX (vmap, post-JIT) | **11.24** |
+
+The vmap speedup is modest (1.29×) because there's no T(k) sharing across
+batch elements — each (M, z) re-evaluates the full Eisenstein-Hu transfer
+on its own 256-point k grid. A future optimisation could hoist T(k) and
+the σ₈ normalisation out of the per-call work for fixed-cosmology batches.
+
+### Differentiability
+
+`jax.grad(c_of_M)(1e12)` returns `dc/dM ≈ −6.34 × 10⁻¹³`. Finite-difference
+comparison against colossus gives `−6.34 × 10⁻¹³` — agreement to 7 × 10⁻⁴
+relative. So **autodiff through the concentration solver works**, which the
+`pure_callback` form cannot offer.
+
+### End-to-end science check (the one that actually matters)
+
+c200c is an internal quantity; what observers fit are the convergence and
+deflection maps of the resulting NFW profile. The c200c error must propagate
+through `mcr_util.kappa_s_and_scale_radius_for_ludlow` → `kappa_s`,
+`scale_radius`, `radius_at_200` → the `NFW` / `cNFW` lensing functions. The
+[`science_check.py`](nfw_ludlow16_jax/science_check.py) script monkey-patches
+`mcr_util` to swap the colossus callback for the JAX prototype, then builds
+the same `ag.mp.NFWMCRScatterLudlowSph` / `ag.mp.cNFWMCRScatterLudlowSph`
+profile both ways and compares all downstream outputs.
+
+**Helper outputs across 4 × 5 × 3 × 3 = 180 (log M, z_lens, z_src, σ_scatter) combinations**
+covering `log M ∈ [10.5, 13.5]`, `z_lens ∈ [0.1, 1.5]`, `z_src ∈ [1.0, 2.5]`,
+scatter ∈ {−1, 0, +1}:
+
+| Quantity | Max relative error |
+|---|---|
+| `kappa_s` | **1.07 × 10⁻³** |
+| `scale_radius` | **7.40 × 10⁻⁴** |
+| `radius_at_200` | **0** (identical — does not depend on concentration) |
+
+**NFW lensing maps** (six representative cases — cluster M=5×10¹⁴ down to
+dwarf M=10¹¹, scatter σ ∈ {−1.5, 0, +1.5}, on 50×50 grids):
+
+| Quantity | Worst over cases | Median over cases |
+|---|---|---|
+| `|Δκ/κ|` | **8.02 × 10⁻⁴** | **6.51 × 10⁻⁴** |
+| `|Δα/α|` (deflection magnitude) | **8.21 × 10⁻⁴** | **6.77 × 10⁻⁴** |
+
+**cNFW deflection maps** (three cases, `f_c ∈ {0.05, 0.10}` where the
+Penarrubia mcr formula is physical):
+
+| Quantity | Worst over cases | Median over cases |
+|---|---|---|
+| `|Δα/α|` | **7.60 × 10⁻⁴** | **4.43 × 10⁻⁴** |
+
+(`cNFWSph.convergence_2d_from` returns zeros — not yet implemented in
+PyAutoGalaxy for the spherical case — so the cNFW convergence column is
+vacuous. The deflection comparison is the meaningful one.)
+
+### Is 10⁻³ "safe enough" for the science?
+
+To convince of this we compare the JAX-vs-colossus discrepancy against the
+sources of uncertainty that already dominate any inference using these
+profiles:
+
+| Source of uncertainty | Typical magnitude in c200c (or equivalent) | Ratio vs JAX-port error (10⁻³) |
+|---|---|---|
+| **Intrinsic scatter** of the Ludlow16 relation itself | σ_log10(c) = 0.13 dex ⇒ ~35% spread in c at fixed M | **≈ 350×** |
+| Cosmology choice — Planck15 vs Planck18 Om0 | ~1% on c200c | ≈ 10× |
+| Cosmology choice — present autogalaxy/colossus Om0 mismatch (0.3075 vs 0.3089) | already in current code, ~0.5% on derived κ | ≈ 5× |
+| Typical photometric S/N per pixel on lensed arcs | rel. flux noise 1–20% | ≈ 10–200× |
+| Posterior uncertainty on `kappa_s` from a real lens fit | typically 1–10% | ≈ 10–100× |
+
+A 10⁻³ deterministic offset is **two-to-three orders of magnitude below** the
+intrinsic Ludlow scatter — the very dispersion the `scatter_sigma` parameter
+exists to marginalise over. The current code already accepts this scatter as
+the relation's inherent imprecision; the JAX port adds nothing measurable on
+top.
+
+The `kappa_s` discrepancy (1 × 10⁻³ relative, 0.1%) is one bit-flip in a
+typical 10-bit posterior coverage on `kappa_s` — invisible in any plausible
+HMC / Nautilus / MultiNest run on real data.
+
+### Verdict on science fidelity
+
+**The JAX port is scientifically indistinguishable from the colossus
+callback for every NFW-MCR and cNFW-MCR profile that calls it.** No fit,
+no posterior, no derived halo property, no derived lensing observable will
+shift in any detectable way. The remaining 10⁻³ offset is structural in
+the EH98 power-spectrum fit vs colossus' tabulated transfer; it does not
+grow under composition with downstream profile evaluations.
+
+## Recommendation
+
+**Adopt Approach A.** It:
+
+- Hits the accuracy budget (7.5 × 10⁻⁴ vs the 1% target).
+- Is faster than the current callback even single-call (0.69 ms vs 0.83 ms),
+  faster batched, and `vmap`-able.
+- Unlocks `jax.grad` end-to-end through any NFW-MCR-Ludlow profile.
+- Eliminates `colossus` as a runtime dependency (still useful for cross-
+  validation in the test suite — could be moved to a test-only / optional dep).
+- Is ~330 lines of straight-line JAX, in one file, with no clever tricks.
+  Maintenance burden is low; the algorithm matches the cited papers
+  (Eisenstein & Hu 1998, Heath 1977, Ludlow et al. 2016) directly.
+
+Approaches B (lookup table) and C (analytic fit) are not needed.
+
+## Proposed Phase 2 implementation plan
+
+A separate follow-up issue will:
+
+1. Move the prototype into `autogalaxy/profiles/mass/dark/ludlow16.py` (or
+   merge it into `mcr_util.py` if the file size stays reasonable).
+2. Collapse `_ludlow16_cosmology_callback` and `ludlow16_cosmology_jax`
+   into a single `xp`-aware `ludlow16_cosmology(mass_at_200, redshift_object,
+   redshift_source, xp=np)`. Numpy path uses `numpy` equivalents of all the
+   JAX functions in the prototype (trivial — the JAX code is `jnp` everywhere,
+   and `numpy` has the same names; only `jax.scipy.special.gammainc` →
+   `scipy.special.gammainc` differs).
+3. Drop the `if xp is np: ... else: ...` branching in
+   `kappa_s_and_scale_radius_for_ludlow` and
+   `kappa_s_scale_radius_and_core_radius_for_ludlow` — both become straight
+   `xp` calls.
+4. Make `colossus` an optional dependency (only used by the test cross-check).
+5. Add unit tests:
+   - Numpy path: regression vs colossus for c200c on a small (log M, z) grid.
+   - JAX path: JIT correctness (the numpy/JAX paths agree), plus a
+     `jax.grad` smoke test (returns a finite, non-NaN gradient).
+6. Validate the five NFW-MCR callers
+   (`nfw_mcr`, `nfw_mcr_scatter`, `nfw_truncated_mcr_scatter`, `gnfw_mcr`,
+   `cnfw_mcr_scatter`) end-to-end under `jax.jit` in
+   `autogalaxy_workspace_test/`.
+
+## How to reproduce
+
+Inside the `feature/nfw-jax-port` worktree:
+
+```bash
+source ~/Code/PyAutoLabs-wt/nfw-jax-port/activate.sh
+cd ~/Code/PyAutoLabs-wt/nfw-jax-port/PyAutoGalaxy
+
+# Accuracy + single-call timing
+JAX_ENABLE_X64=1 NUMBA_CACHE_DIR=/tmp/numba_cache \
+    MPLCONFIGDIR=/tmp/matplotlib \
+    python docs/research/nfw_ludlow16_jax/validate.py
+
+# grad correctness + vmap timing
+JAX_ENABLE_X64=1 NUMBA_CACHE_DIR=/tmp/numba_cache \
+    MPLCONFIGDIR=/tmp/matplotlib \
+    python docs/research/nfw_ludlow16_jax/bench.py
+
+# nk / nz grid sweep
+JAX_ENABLE_X64=1 NUMBA_CACHE_DIR=/tmp/numba_cache \
+    MPLCONFIGDIR=/tmp/matplotlib \
+    python docs/research/nfw_ludlow16_jax/tune.py
+```


### PR DESCRIPTION
## Summary

Phase 1 deliverable for #397 — assess whether the `jax.pure_callback` wrapping `colossus.halo.concentration` in `autogalaxy/profiles/mass/dark/mcr_util.py` can be replaced by a JAX-native implementation.

**Verdict: yes, Approach A is viable.** A full port of `modelLudlow16` — Eisenstein-Hu '98 transfer + Heath '77 growth factor + Einasto `gammainc` + 200-point Ludlow16 solver — comes to ~330 lines of straight-line JAX in one file. Max relative error in c200c vs colossus over the lensing parameter grid (log M ∈ [10, 14] Msun/h, z ∈ [0.1, 2.5]) is **7.5 × 10⁻⁴**. Single-call post-JIT is 0.69 ms vs colossus' 0.83 ms. `jax.grad` works end-to-end; `vmap × 32` is 1.29× faster than colossus serial.

End-to-end propagation through `NFWMCRScatterLudlow` and `cNFWMCRScatterLudlow`:
- `kappa_s` max rel error: **1.07 × 10⁻³**
- NFW convergence/deflection per-pixel max rel error: **8.21 × 10⁻⁴**
- cNFW deflection per-pixel max rel error: **7.60 × 10⁻⁴**

The intrinsic scatter of the Ludlow16 relation itself (`σ_log10(c) = 0.13 dex`, the dispersion the `scatter_sigma` parameter marginalises over) is ~350× larger than this offset. Scientifically invisible.

No production code is changed in this PR. All artefacts live under `docs/research/nfw_ludlow16_jax/` and serve as the basis for a separate Phase 2 PR that will swap the prototype into `mcr_util.py`, collapse the JAX/NumPy branches in the two callers, and make `colossus` an optional dependency.

## API Changes

None — internal changes only (research artefact in `docs/research/`).

## Test Plan

- [ ] `python -m pytest test_autogalaxy/` passes (production code is untouched).
- [ ] Reproduce the report numbers per instructions in `docs/research/nfw_ludlow16_jax_assessment.md`:
  ```
  source ~/Code/PyAutoLabs-wt/nfw-jax-port/activate.sh
  cd ~/Code/PyAutoLabs-wt/nfw-jax-port/PyAutoGalaxy
  JAX_ENABLE_X64=1 NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \
      python docs/research/nfw_ludlow16_jax/validate.py
  ```
- [ ] Confirm `docs/research/nfw_ludlow16_jax_assessment.md` renders cleanly on GitHub.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `docs/research/nfw_ludlow16_jax_assessment.md` — feasibility report.
- `docs/research/nfw_ludlow16_jax/ludlow16_jax.py` — Approach A prototype (~330 lines: EH98 transfer, σ(R) via top-hat log-k quadrature, flat-LCDM growth factor via Heath '77 integral, Einasto `gammainc` mass ratio, 200-point Ludlow16 c-solver).
- `docs/research/nfw_ludlow16_jax/validate.py` — accuracy comparison vs colossus over the lensing parameter grid.
- `docs/research/nfw_ludlow16_jax/bench.py` — `jax.grad` correctness + `jax.vmap` timing.
- `docs/research/nfw_ludlow16_jax/tune.py` — `(nk, nz)` quadrature grid sweep.
- `docs/research/nfw_ludlow16_jax/science_check.py` — end-to-end NFW / cNFW lensing comparison (helper outputs + convergence + deflection maps).

### Removed
None.

### Renamed
None.

### Changed Signature
None.

### Changed Behaviour
None.

### Migration
N/A — no production API is touched.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)