### PR TITLE
feat: wire ag.VisualizerQuantity through fit_for_visualization

### DIFF
--- a/autogalaxy/quantity/model/analysis.py
+++ b/autogalaxy/quantity/model/analysis.py
@@ -143,6 +143,19 @@ class AnalysisQuantity(Analysis):
             dataset=self.dataset, light_mass_obj=galaxies, func_str=self.func_str
         )
 
+    def fit_from(self, instance: af.ModelInstance) -> FitQuantity:
+        """
+        Standard-name alias for :meth:`fit_quantity_for_instance`.
+
+        Exposing ``fit_from`` lets the autofit base ``Analysis.fit_for_visualization``
+        helper dispatch through the same JIT-cached wrapper as imaging /
+        interferometer (it calls ``self.fit_from`` unconditionally). Without
+        this method, ``use_jax_for_visualization=True`` on ``AnalysisQuantity``
+        would be a silent no-op — see the Phase 0c shipped notes in
+        ``PyAutoPrompt/complete.md``.
+        """
+        return self.fit_quantity_for_instance(instance=instance)
+
     def save_attributes(self, paths: af.DirectoryPaths):
         """
         Before the non-linear search begins, this routine saves attributes of the `Analysis` object to the `files`

--- a/autogalaxy/quantity/model/visualizer.py
+++ b/autogalaxy/quantity/model/visualizer.py
@@ -69,7 +69,7 @@ class VisualizerQuantity(af.Visualizer):
         if skip_visualization():
             return
 
-        fit = analysis.fit_quantity_for_instance(instance=instance)
+        fit = analysis.fit_for_visualization(instance=instance)
 
         plotter = PlotterQuantity(
             image_path=paths.image_path, title_prefix=analysis.title_prefix


### PR DESCRIPTION
## Summary

`ag.VisualizerQuantity.visualize` bypassed `analysis.fit_for_visualization` entirely — it called `analysis.fit_quantity_for_instance(instance)` directly. That made `use_jax_for_visualization=True` a silent no-op for `AnalysisQuantity` despite #401 shipping the `FitQuantity` pytree registration and `**kwargs` passthrough.

This PR adds a 1-line `fit_from` alias on `AnalysisQuantity` (so the autofit base `Analysis.fit_for_visualization` helper, which dispatches through `self.fit_from`, can find it) and swaps the visualizer call from `fit_quantity_for_instance` to `fit_for_visualization`.

Net effect: `use_jax_for_visualization=True` on `ag.AnalysisQuantity` now actually fires the JIT-cached path.

## API Changes

- Added: `ag.AnalysisQuantity.fit_from(instance)` — thin alias for the existing `fit_quantity_for_instance(instance)`. Required so the autofit base `Analysis.fit_for_visualization` dispatcher can find a `fit_from` method on this analysis class (mirrors the imaging/interferometer pattern).

Strictly additive — no existing call site is affected. `fit_quantity_for_instance` retained for backwards compatibility.

See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/quantity/` — 18/18 tests pass.
- [x] Interactive alias smoke: `analysis.fit_from(instance)` returns the same `FitQuantity` (same dataset reference) as `analysis.fit_quantity_for_instance(instance)`.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `ag.AnalysisQuantity.fit_from(instance)` — alias for `fit_quantity_for_instance(instance)`. Exposing the canonical `fit_from` name lets `Analysis.fit_for_visualization` dispatch through this class for the first time.

### Changed Behaviour

- `ag.VisualizerQuantity.visualize` now constructs its fit via `analysis.fit_for_visualization(instance)` rather than `analysis.fit_quantity_for_instance(instance)`. Behaviour identical when `use_jax_for_visualization=False` (`fit_for_visualization` falls back to `fit_from`). When `True`, the JIT-cached wrapper from autofit takes over — previously this kwarg was silently ignored on `AnalysisQuantity`.

### Migration

None required for users.

### Roadmap context

This is a follow-up to Phase 0c (#401), which registered `FitQuantity` as a pytree and added `**kwargs` passthrough on `AnalysisQuantity.__init__` but did **not** wire the visualizer dispatch. With this PR, the autogalaxy quantity side of the JAX visualization roadmap is fully wired. A small follow-up Phase 1C-extension PR can now add `autogalaxy_workspace_test/scripts/quantity/visualization_jax.py` to exercise the path end-to-end.

`ag.VisualizerEllipse` is **not** included — its `analysis.fit_list_from` returns `List[FitEllipse]` rather than a single fit, which doesn't match the `fit_for_visualization` contract. Needs autofit-side contract design before it can be wired similarly.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)