### PR TITLE
fix: register DatasetModel pytree in _register_fit_quantity_pytrees

### DIFF
--- a/autogalaxy/quantity/model/analysis.py
+++ b/autogalaxy/quantity/model/analysis.py
@@ -78,12 +78,14 @@ class AnalysisQuantity(Analysis):
         carry the traced model arrays and ride as pytree children.
         """
         from autoarray.abstract_ndarray import register_instance_pytree
+        from autoarray.dataset.dataset_model import DatasetModel
         from autogalaxy.analysis.jax_pytrees import register_galaxies_pytree
 
         register_instance_pytree(
             FitQuantity,
             no_flatten=("dataset", "func_str", "use_mask_in_fit"),
         )
+        register_instance_pytree(DatasetModel)
         register_galaxies_pytree()
 
     def log_likelihood_function(self, instance: af.ModelInstance) -> float:


### PR DESCRIPTION
## Summary

The imaging and interferometer analogues both register `DatasetModel` alongside their `Fit*` class (`autogalaxy/imaging/model/analysis.py:186`, `autogalaxy/interferometer/model/analysis.py:183`). The quantity registration shipped in #401 omitted it, leaving a `TypeError` trap: when `jax.jit` flattens a `FitQuantity`, the `DatasetModel` attribute (reachable via the `aa.FitImaging` base-class) hits "not a valid JAX type" because it's neither static-aux nor a registered pytree.

Surfaced when writing `autogalaxy_workspace_test/scripts/quantity/visualization_jax.py` (the autogalaxy quantity Phase 1C-extension follow-up). The script needed a `register_instance_pytree(DatasetModel)` workaround at module level just to JIT-flatten the fit returned by `analysis.fit_for_visualization`.

This PR adds the missing `register_instance_pytree(DatasetModel)` call to `_register_fit_quantity_pytrees`, mirroring the imaging and interferometer registrations. The workaround in the workspace_test JAX script will be removed in the follow-up workspace_test PR.

## API Changes

None visible to callers. `_register_fit_quantity_pytrees` is a private side-effect method invoked under `if use_jax:` in `AnalysisQuantity.__init__`. After this PR it registers one additional class (`DatasetModel`) as a pytree, which the imaging and interferometer analyses have always done.

See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/quantity/` — 18/18 tests pass.
- [ ] After merge: the workspace_test follow-up (`autogalaxy_workspace_test/scripts/quantity/visualization_jax.py`) drops its `register_instance_pytree(DatasetModel)` workaround and continues to pass.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour

- `AnalysisQuantity._register_fit_quantity_pytrees` now also registers `DatasetModel` as a pytree (in addition to `FitQuantity` and `Galaxies`). Brings the quantity registration to parity with imaging (`_register_fit_imaging_pytrees`) and interferometer (`_register_fit_interferometer_pytrees`). Fires once per process when `AnalysisQuantity` is constructed with `use_jax=True`.

### Migration

None.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)