### PR TITLE
refactor: parameterise Ellipse + EllipseMultipole math on xp

### DIFF
--- a/autogalaxy/ellipse/ellipse/ellipse.py
+++ b/autogalaxy/ellipse/ellipse/ellipse.py
@@ -106,7 +106,7 @@ class Ellipse(EllProfile):
 
         return np.min([500, int(np.round(circular_radius_pixels, 1))])
 
-    def angles_from_x0_from(self, pixel_scale: float, n_i: int = 0) -> np.ndarray:
+    def angles_from_x0_from(self, pixel_scale: float, n_i: int = 0, xp=np) -> np.ndarray:
         """
         Returns the angles from the x-axis to a discrete number of points ranging from 0.0 to 2.0 * np.pi radians.
 
@@ -136,10 +136,10 @@ class Ellipse(EllProfile):
         """
         total_points = self.total_points_from(pixel_scale)
 
-        return np.linspace(0.0, 2.0 * np.pi, total_points + n_i)[:-1]
+        return xp.linspace(0.0, 2.0 * np.pi, total_points + n_i)[:-1]
 
     def ellipse_radii_from_major_axis_from(
-        self, pixel_scale: float, n_i: int = 0
+        self, pixel_scale: float, n_i: int = 0, xp=np
     ) -> np.ndarray:
         """
         Returns the distance from the centre of the ellipse to every point on the ellipse, which are called
@@ -161,21 +161,21 @@ class Ellipse(EllProfile):
         The ellipse radii from the major-axis of the ellipse.
         """
 
-        angles_from_x0 = self.angles_from_x0_from(pixel_scale=pixel_scale, n_i=n_i)
+        angles_from_x0 = self.angles_from_x0_from(pixel_scale=pixel_scale, n_i=n_i, xp=xp)
 
-        return np.divide(
+        return xp.divide(
             self.major_axis * self.minor_axis,
-            np.sqrt(
-                np.add(
+            xp.sqrt(
+                xp.add(
                     self.major_axis**2.0
-                    * np.sin(angles_from_x0 - self.angle_radians()) ** 2.0,
+                    * xp.sin(angles_from_x0 - self.angle_radians()) ** 2.0,
                     self.minor_axis**2.0
-                    * np.cos(angles_from_x0 - self.angle_radians()) ** 2.0,
+                    * xp.cos(angles_from_x0 - self.angle_radians()) ** 2.0,
                 )
             ),
         )
 
-    def x_from_major_axis_from(self, pixel_scale: float, n_i: int = 0) -> np.ndarray:
+    def x_from_major_axis_from(self, pixel_scale: float, n_i: int = 0, xp=np) -> np.ndarray:
         """
         Returns the x-coordinates of the points on the ellipse, starting from the x-coordinate of the major-axis
         of the ellipse after rotation by its `angle` and moving counter-clockwise.
@@ -193,14 +193,14 @@ class Ellipse(EllProfile):
         The x-coordinates of the points on the ellipse.
         """
 
-        angles_from_x0 = self.angles_from_x0_from(pixel_scale=pixel_scale, n_i=n_i)
+        angles_from_x0 = self.angles_from_x0_from(pixel_scale=pixel_scale, n_i=n_i, xp=xp)
         ellipse_radii_from_major_axis = self.ellipse_radii_from_major_axis_from(
-            pixel_scale=pixel_scale, n_i=n_i
+            pixel_scale=pixel_scale, n_i=n_i, xp=xp
         )
 
-        return ellipse_radii_from_major_axis * np.cos(angles_from_x0) + self.centre[1]
+        return ellipse_radii_from_major_axis * xp.cos(angles_from_x0) + self.centre[1]
 
-    def y_from_major_axis_from(self, pixel_scale: float, n_i: int = 0) -> np.ndarray:
+    def y_from_major_axis_from(self, pixel_scale: float, n_i: int = 0, xp=np) -> np.ndarray:
         """
         Returns the y-coordinates of the points on the ellipse, starting from the y-coordinate of the major-axis
         of the ellipse after rotation by its `angle` and moving counter-clockwise.
@@ -221,13 +221,13 @@ class Ellipse(EllProfile):
         -------
         The y-coordinates of the points on the ellipse.
         """
-        angles_from_x0 = self.angles_from_x0_from(pixel_scale=pixel_scale, n_i=n_i)
+        angles_from_x0 = self.angles_from_x0_from(pixel_scale=pixel_scale, n_i=n_i, xp=xp)
         ellipse_radii_from_major_axis = self.ellipse_radii_from_major_axis_from(
-            pixel_scale=pixel_scale, n_i=n_i
+            pixel_scale=pixel_scale, n_i=n_i, xp=xp
         )
 
         return (
-            -1.0 * (ellipse_radii_from_major_axis * np.sin(angles_from_x0))
+            -1.0 * (ellipse_radii_from_major_axis * xp.sin(angles_from_x0))
             - self.centre[0]
         )
 
@@ -235,6 +235,7 @@ class Ellipse(EllProfile):
         self,
         pixel_scale: float,
         n_i: int = 0,
+        xp=np,
     ) -> np.ndarray:
         """
         Returns the (y,x) coordinates of the points on the ellipse, starting from the major-axis of the ellipse
@@ -256,11 +257,12 @@ class Ellipse(EllProfile):
         The (y,x) coordinates of the points on the ellipse.
         """
 
-        x = self.x_from_major_axis_from(pixel_scale=pixel_scale, n_i=n_i)
-        y = self.y_from_major_axis_from(pixel_scale=pixel_scale, n_i=n_i)
+        x = self.x_from_major_axis_from(pixel_scale=pixel_scale, n_i=n_i, xp=xp)
+        y = self.y_from_major_axis_from(pixel_scale=pixel_scale, n_i=n_i, xp=xp)
 
-        idx = np.logical_or(np.isnan(x), np.isnan(y))
-        if np.sum(idx) > 0.0:
-            raise NotImplementedError()
+        if xp is np:
+            idx = np.logical_or(np.isnan(x), np.isnan(y))
+            if np.sum(idx) > 0:
+                raise NotImplementedError()
 
-        return np.stack(arrays=(y, x), axis=-1)
+        return xp.stack(arrays=(y, x), axis=-1)

--- a/autogalaxy/ellipse/ellipse/ellipse_multipole.py
+++ b/autogalaxy/ellipse/ellipse/ellipse_multipole.py
@@ -41,6 +41,7 @@ class EllipseMultipole:
     def get_shape_angle(
         self,
         ellipse: Ellipse,
+        xp=np,
     ) -> float:
         """
         The shape angle is the offset between the angle of the ellipse and the angle of the multipole,
@@ -53,25 +54,24 @@ class EllipseMultipole:
         ----------
         ellipse
             The base ellipse profile that is perturbed by the multipole.
+        xp
+            The array module to use (default: numpy).
 
         Returns
         -------
         The angle between the ellipse and the multipole, in degrees between +- 180/m.
+        The boundary case `angle == period/2.0` exactly maps to `-period/2.0` after wrap.
         """
 
         angle = (
             ellipse.angle()
             - multipole_k_m_and_phi_m_from(self.multipole_comps, self.m)[1]
         )
-        while angle < -180 / self.m:
-            angle += 360 / self.m
-        while angle > 180 / self.m:
-            angle -= 360 / self.m
-
-        return angle
+        period = 360.0 / self.m
+        return xp.mod(angle + period / 2.0, period) - period / 2.0
 
     def points_perturbed_from(
-        self, pixel_scale, points, ellipse: Ellipse, n_i: int = 0
+        self, pixel_scale, points, ellipse: Ellipse, n_i: int = 0, xp=np
     ) -> np.ndarray:
         """
         Returns the (y,x) coordinates of the input points, which are perturbed by the multipole of the ellipse.
@@ -84,6 +84,8 @@ class EllipseMultipole:
             The (y,x) coordinates of the ellipse that are perturbed by the multipole.
         ellipse
             The ellipse that is perturbed by the multipole, which is used to compute the angles of the ellipse.
+        xp
+            The array module to use (default: numpy).
 
         Returns
         -------
@@ -100,19 +102,19 @@ class EllipseMultipole:
         )
 
         # 1) compute cartesian (polar) angle
-        theta = np.arctan2(points[:, 0], points[:, 1])  # <- true polar angle
+        theta = xp.arctan2(points[:, 0], points[:, 1])  # <- true polar angle
 
         # 2) multipole in that same frame
         delta_theta = self.m * (theta - ellipse.angle_radians())
-        radial = comps_adjusted[1] * np.cos(delta_theta) + comps_adjusted[0] * np.sin(
+        radial = comps_adjusted[1] * xp.cos(delta_theta) + comps_adjusted[0] * xp.sin(
             delta_theta
         )
 
         # 3) perturb along the true radial direction
-        x = points[:, 1] + radial * np.cos(theta)
-        y = points[:, 0] + radial * np.sin(theta)
+        x = points[:, 1] + radial * xp.cos(theta)
+        y = points[:, 0] + radial * xp.sin(theta)
 
-        return np.stack((y, x), axis=-1)
+        return xp.stack((y, x), axis=-1)
 
 
 class EllipseMultipoleScaled(EllipseMultipole):
@@ -165,7 +167,7 @@ class EllipseMultipoleScaled(EllipseMultipole):
         self.m = m
 
     def points_perturbed_from(
-        self, pixel_scale, points, ellipse: Ellipse, n_i: int = 0
+        self, pixel_scale, points, ellipse: Ellipse, n_i: int = 0, xp=np
     ) -> np.ndarray:
         """
         Returns the (y,x) coordinates of the input points, which are perturbed by the multipole of the ellipse.
@@ -178,6 +180,8 @@ class EllipseMultipoleScaled(EllipseMultipole):
             The (y,x) coordinates of the ellipse that are perturbed by the multipole.
         ellipse
             The ellipse that is perturbed by the multipole, which is used to compute the angles of the ellipse.
+        xp
+            The array module to use (default: numpy).
 
         Returns
         -------
@@ -194,11 +198,11 @@ class EllipseMultipoleScaled(EllipseMultipole):
         )
 
         # 1) compute cartesian (polar) angle
-        theta = np.arctan2(points[:, 0], points[:, 1])  # <- true polar angle
+        theta = xp.arctan2(points[:, 0], points[:, 1])  # <- true polar angle
 
         # 2) multipole in that same frame
         delta_theta = self.m * (theta - ellipse.angle_radians())
-        radial = comps_adjusted[1] * np.cos(delta_theta) + comps_adjusted[0] * np.sin(
+        radial = comps_adjusted[1] * xp.cos(delta_theta) + comps_adjusted[0] * xp.sin(
             delta_theta
         )
 
@@ -212,7 +216,7 @@ class EllipseMultipoleScaled(EllipseMultipole):
         #         )
 
         # 3) perturb along the true radial direction
-        x = points[:, 1] + radial * np.cos(theta)
-        y = points[:, 0] + radial * np.sin(theta)
+        x = points[:, 1] + radial * xp.cos(theta)
+        y = points[:, 0] + radial * xp.sin(theta)
 
-        return np.stack(arrays=(y, x), axis=-1)
+        return xp.stack(arrays=(y, x), axis=-1)

--- a/test_autogalaxy/ellipse/ellipse/test_ellipse.py
+++ b/test_autogalaxy/ellipse/ellipse/test_ellipse.py
@@ -152,3 +152,24 @@ def test__points_from_major_axis():
     assert ellipse.points_from_major_axis_from(pixel_scale=1.0)[1][0] == pytest.approx(
         -0.2123224755, 1.0e-4
     )
+
+
+def test__multipole__get_shape_angle__boundary_returns_neg_half_period():
+    # The xp.mod rewrite maps boundary case `period/2.0` to `-period/2.0`
+    # (closed-open interval), unlike the old while-loop which returned `period/2.0`
+    # (open-closed). This test pins the new convention.
+    multipole = ag.EllipseMultipole(m=4, multipole_comps=(0.0, 0.0))
+    # period = 360 / 4 = 90; choose ellipse.angle() such that the unnormalised
+    # offset equals exactly +period/2 = 45.0 degrees.
+    # multipole_k_m_and_phi_m_from((0.0, 0.0), m=4) returns phi_m = 0, k = 0.
+    # So angle_offset = ellipse.angle() - phi_m = ellipse.angle().
+    # We want that to be exactly +45.0 so that after wrap it lands at -45.0.
+    # ellipse.angle() depends on ell_comps. Easiest: derive ell_comps via
+    # ag.convert.ell_comps_from(axis_ratio=..., angle=45.0).
+    ellipse = ag.Ellipse(
+        centre=(0.0, 0.0),
+        ell_comps=ag.convert.ell_comps_from(axis_ratio=0.5, angle=45.0),
+        major_axis=1.0,
+    )
+    result = multipole.get_shape_angle(ellipse=ellipse)
+    assert result == pytest.approx(-45.0, abs=1e-9)


### PR DESCRIPTION
## Summary

Add an `xp=np` keyword parameter to every numeric method on `Ellipse`, `EllipseMultipole`, and `EllipseMultipoleScaled`, replacing bare `np.*` calls with `xp.*` so the geometry math traces under `jax.jit`. Rewrite `EllipseMultipole.get_shape_angle`'s two Python `while` loops as a single `xp.mod` arithmetic wrap. Gate the NaN-raise in `points_from_major_axis_from` behind `if xp is np:` so the JIT path can let NaNs propagate through downstream `nansum` / `nanmean` reductions.

Step 5 of 7 in `z_features/ellipse_fitting_jax.md`. NumPy-path behaviour preserved — `xp=np` is the default at every entry point and call sites in `FitEllipse` continue to pass nothing. The prompt-2 workspace reference numbers stay byte-stable to all 8 printed decimal places; the prompt-3 `rtol=1e-12` reference arrays on `_points_from_major_axis` continue to pass.

JAX trace check confirmed: `jax.jit(lambda ps: ellipse.points_from_major_axis_from(pixel_scale=ps, xp=jnp))` compiles cleanly to shape `(61, 2)`. Note: `pixel_scale` must be a concrete Python value (not a traced argument) because `total_points_from` uses it to compute a static array size — by design, since this is a shape parameter.

## API Changes

Eight methods on `Ellipse` / `EllipseMultipole` / `EllipseMultipoleScaled` gain an `xp=np` keyword (purely additive — existing callers unaffected). One behaviour change: `EllipseMultipole.get_shape_angle` previously wrapped angles into the open-closed interval `(-period/2, period/2]` via two `while` loops; the `xp.mod` rewrite wraps into the closed-open interval `[-period/2, period/2)`, so the single boundary value `angle == period/2.0` exactly now returns `-period/2.0` instead of `+period/2.0`. A new test pins the new convention. No removals, no other behaviour changes. See full details below.

## Test Plan

- [ ] `python -m pytest test_autogalaxy/ellipse/ -v` — 31/31 pass (30 existing + 1 new boundary test)
- [ ] `python -m pytest test_autogalaxy/ -x` — 869/869 pass, no regressions
- [ ] `python scripts/jax_likelihood_functions/ellipse/{fit,multipoles}.py` from `autogalaxy_workspace_test/` — all 8 prompt-2 reference numbers match byte-for-byte
- [ ] Per `PyAutoGalaxy/CLAUDE.md` "Never use JAX in unit tests" rule, no JAX imports were added to `test_autogalaxy/`. JAX parity is verified at the workspace_test level by prompt 7 once `AnalysisEllipse` flips to the JIT path.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added (keyword-only, all default `xp=np`)
- `Ellipse.angles_from_x0_from(..., xp=np)`
- `Ellipse.ellipse_radii_from_major_axis_from(..., xp=np)`
- `Ellipse.x_from_major_axis_from(..., xp=np)`
- `Ellipse.y_from_major_axis_from(..., xp=np)`
- `Ellipse.points_from_major_axis_from(..., xp=np)`
- `EllipseMultipole.get_shape_angle(ellipse, xp=np)`
- `EllipseMultipole.points_perturbed_from(..., xp=np)`
- `EllipseMultipoleScaled.points_perturbed_from(..., xp=np)`

### Removed
None.

### Changed Behaviour
- `EllipseMultipole.get_shape_angle`: boundary case `angle == period/2.0` (where `period = 360/m`) now returns `-period/2.0` (closed-open interval `[-period/2, period/2)`) where previously it returned `+period/2.0` (open-closed `(-period/2, period/2]`). The new `xp.mod`-based wrap is JIT-traceable. Pinned by `test__multipole__get_shape_angle__boundary_returns_neg_half_period`.
- `Ellipse.points_from_major_axis_from`: the NaN-raise (`raise NotImplementedError()` if any output coordinate is NaN) is now skipped when `xp is not np`. Under JAX, NaNs propagate through downstream `nansum`/`nanmean` reductions instead of raising at JIT-trace time.

### Migration
- Existing callers: no change. `xp` is keyword-only with a default of `np`; the eight methods continue to behave identically for `xp=np`.
- New JAX path: pass `xp=jnp` to opt in. Note that `pixel_scale` is a shape parameter — pass a concrete Python value, not a JAX tracer, when JIT-wrapping.
- Code that relied on `get_shape_angle` returning exactly `+period/2.0` at the boundary needs to flip to `-period/2.0`. Search-and-replace target: equality against `+45.0` (or `+90.0`, `+30.0`, etc.) following a `get_shape_angle()` call. We don't believe any callers depend on this; the test pins the new behaviour going forward.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)