### PR TITLE
fix: add quick_update kwarg to VisualizerImaging.visualize_combined

### DIFF
--- a/autogalaxy/imaging/model/visualizer.py
+++ b/autogalaxy/imaging/model/visualizer.py
@@ -146,6 +146,7 @@ class VisualizerImaging(af.Visualizer):
         paths: af.AbstractPaths,
         instance: af.ModelInstance,
         during_analysis: bool,
+        quick_update: bool = False,
     ):
         """
         Performs visualization during the non-linear search of information which is shared across all analyses on a


### PR DESCRIPTION
## Summary
Adds the `quick_update: bool = False` kwarg to `VisualizerImaging.visualize_combined` (`autogalaxy/imaging/model/visualizer.py:144`). Mirrors the PyAutoFit-side fix in [PyAutoLabs/PyAutoFit#1267](https://github.com/PyAutoLabs/PyAutoFit/pull/1267) on the same branch name. The plumbing was introduced by PyAutoFit commit `a1e360567` ("Fix `AnalysisFactor.visualize_combined` dispatch in FactorGraph") which updated PyAutoLens's `VisualizerImaging` + `VisualizerInterferometer` but missed PyAutoGalaxy's `VisualizerImaging`.

Today any `FactorGraphModel` fit that uses `autogalaxy.AnalysisImaging` crashes on the first quick-update iteration with `TypeError: VisualizerImaging.visualize_combined() got an unexpected keyword argument 'quick_update'`.

Pure additive — kwarg defaults to `False` and the body (which handles imaging fit visualisation) is unchanged.

This was surfaced during follow-up audit work for PyAutoLabs/PyAutoFit#1262 (priors-jax-native).

## API Changes
Added `quick_update: bool = False` kwarg to `VisualizerImaging.visualize_combined`. Purely additive — existing call sites still work because the kwarg has a default.
See full details below.

## Test Plan
- [x] `pytest test_autogalaxy/imaging/model` — 10 passed
- [x] Cross-validated against PyAutoFit-side fix on same branch — all four previously-broken `FactorGraphModel` integration scripts (`graphical/simultaneous.py`, `graphical/hierarchical.py`, `features/graphical_models.py`, `cookbooks/multiple_datasets.py`) now pass end-to-end.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `VisualizerImaging.visualize_combined(analyses, paths, instance, during_analysis, quick_update=False)` — new `quick_update` kwarg matching the base class signature.

### Migration
None required. Pure addition with a default value.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)