### PR TITLE
config: add prior defaults for ExternalPotential

### DIFF
--- a/autogalaxy/config/priors/mass/sheets/external_potential.yaml
+++ b/autogalaxy/config/priors/mass/sheets/external_potential.yaml
@@ -1,0 +1,81 @@
+ExternalPotential:
+  centre_0:
+    type: Gaussian
+    mean: 0.0
+    sigma: 0.1
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  centre_1:
+    type: Gaussian
+    mean: 0.0
+    sigma: 0.1
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  gamma_1:
+    type: Uniform
+    lower_limit: -0.3
+    upper_limit: 0.3
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  gamma_2:
+    type: Uniform
+    lower_limit: -0.3
+    upper_limit: 0.3
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  tau_1:
+    type: Uniform
+    lower_limit: -0.3
+    upper_limit: 0.3
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  tau_2:
+    type: Uniform
+    lower_limit: -0.3
+    upper_limit: 0.3
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  delta_1:
+    type: Uniform
+    lower_limit: -0.3
+    upper_limit: 0.3
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  delta_2:
+    type: Uniform
+    lower_limit: -0.3
+    upper_limit: 0.3
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf


### PR DESCRIPTION
## Summary
Follow-up to #422. Adds the missing library-default prior YAML for `ag.mp.ExternalPotential` so `af.Model(ag.mp.ExternalPotential)` resolves without a config error.

- `centre_0`, `centre_1`: `Gaussian(0, 0.1)` — matches `Isothermal` and `MassSheet` conventions.
- `gamma_1`, `gamma_2`, `tau_1`, `tau_2`, `delta_1`, `delta_2`: `Uniform(-0.3, 0.3)` with `Absolute` width_modifier `0.05` — mirrors `ExternalShear`'s gamma priors.

Verified locally: `af.Model(ag.mp.ExternalPotential)` builds an 8-parameter (centre + 6 components — `ell_comps` are fixed (0,0) so excluded from priors) model with all medians at 0 as expected.

## API Changes
None — config-only addition. See full details below.

## Test Plan
- [ ] `python -c "import autofit as af, autogalaxy as ag; af.Model(ag.mp.ExternalPotential).instance_from_prior_medians()"` returns the class with all priors resolved.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autogalaxy/config/priors/mass/sheets/external_potential.yaml` — library default priors for `ExternalPotential`.

### Changed
None.

### Removed
None.

### Migration
None — workspace clones that want different priors can shadow this file with their own `config/priors/mass/sheets/external_potential.yaml`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)