### PR TITLE
fix: Basis.image_2d_from and dPIEPotential.convergence_2d_from return wrong wrapper types

### DIFF
--- a/autogalaxy/profiles/basis.py
+++ b/autogalaxy/profiles/basis.py
@@ -147,7 +147,9 @@ class Basis(LightProfile, MassProfile):
                     grid=grid, xp=xp, operated_only=operated_only
                 )
                 if not isinstance(light_profile, lp_linear.LightProfileLinear)
-                else xp.zeros((grid.shape[0],))
+                else aa.Array2D(
+                    values=xp.zeros((grid.shape[0],)), mask=grid.mask
+                )
             )
             for light_profile in self.light_profile_list
         ]

--- a/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_potential.py
+++ b/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_potential.py
@@ -118,7 +118,7 @@ class dPIEPotential(MassProfile):
 
         return xp.vstack((deflection_y, deflection_x)).T
 
-    @aa.decorators.to_vector_yx
+    @aa.decorators.to_array
     @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """

--- a/test_autogalaxy/profiles/mass/total/test_dual_pseudo_isothermal_potential.py
+++ b/test_autogalaxy/profiles/mass/total/test_dual_pseudo_isothermal_potential.py
@@ -1,8 +1,21 @@
 import pytest
 
+import autoarray as aa
 import autogalaxy as ag
 
 grid = ag.Grid2DIrregular([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [2.0, 4.0]])
+
+
+def test__convergence_2d_from__returns_array2d_not_vector():
+    # Regression test for a copy-paste typo: convergence_2d_from used to be
+    # decorated with @aa.decorators.to_vector_yx (the deflections decorator
+    # directly above it) which wrapped the scalar convergence in a VectorYX2D.
+    # The correct decorator is @aa.decorators.to_array.
+    mp = ag.mp.dPIEPotential(centre=(0.0, 0.0), ell_comps=(0.05, 0.0), ra=0.2, rs=2.0, b0=1.0)
+
+    convergence = mp.convergence_2d_from(grid=grid)
+
+    assert isinstance(convergence, aa.ArrayIrregular)
 
 
 def test__deflections_yx_2d_from__sph_config_1():

--- a/test_autogalaxy/profiles/test_basis.py
+++ b/test_autogalaxy/profiles/test_basis.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import autoarray as aa
 import autogalaxy as ag
 
 
@@ -40,6 +41,24 @@ def test__image_2d_from__does_not_include_linear_light_profiles(grid_2d_7x7):
     image = basis.image_2d_from(grid=grid_2d_7x7)
 
     assert (image == lp_image).all()
+
+
+def test__image_2d_from__returns_array2d_for_linear_only_basis(grid_2d_7x7):
+    # Regression test for the case where every constituent is a LightProfileLinear:
+    # the placeholder for the linear-intensity-unknown image used to be a raw
+    # ndarray of zeros, which made `sum(...)` return a raw ndarray rather than an
+    # `Array2D`.  After the fix the placeholder is itself an `Array2D` so the
+    # summed return type is uniform regardless of the constituent mix.
+    basis = ag.lp_basis.Basis(
+        profile_list=[
+            ag.lp_linear.Gaussian(sigma=0.5),
+            ag.lp_linear.Gaussian(sigma=1.0),
+        ]
+    )
+
+    image = basis.image_2d_from(grid=grid_2d_7x7)
+
+    assert isinstance(image, aa.Array2D)
 
 
 def test__image_2d_from__operated_only_false__returns_only_non_operated_profile_image(


### PR DESCRIPTION
## Summary

Two profile-return-type bugs surfaced while writing the new
`autolens_workspace/scripts/guides/profiles/{light,mass}.py` guides (#86 / #176 / #178 /
#179). Both forced workarounds in the workspace guides; both are tiny library-side fixes
that tighten the type contract advertised by the methods' annotations.

Closes #424.

## API Changes

None — return-type fix only. `Basis.image_2d_from` and
`dPIEPotential.convergence_2d_from` already advertised `aa.Array2D` return types in their
annotations; this PR makes the runtime behaviour match. Any caller that already relies on
the (incorrect) `numpy.ndarray` / `VectorYX2D` returns will see a tighter type — none in
the codebase or workspaces do, since both methods were unusable through
`aplt.plot_array` before this fix.
See full details below.

## Test Plan

- [ ] `python -m pytest test_autogalaxy/` passes (full test suite as baseline)
- [ ] New regression tests in `test_basis.py` and `test_dual_pseudo_isothermal_potential.py` pass
- [ ] Sanity-check via the autolens_workspace guides:
  - `aplt.plot_array(array=basis.image_2d_from(grid=grid))` now works for a basis of `lp_linear` constituents (no Galaxy wrap needed).
  - `aplt.plot_array(array=mp.dPIEPotential(...).convergence_2d_from(grid=grid))` now works.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Fixed
- `autogalaxy.profiles.basis.Basis.image_2d_from` — previously returned a raw `numpy.ndarray` when the basis contained only `LightProfileLinear` constituents (the MGE case); now returns `aa.Array2D` uniformly.
- `autogalaxy.profiles.mass.total.dual_pseudo_isothermal_potential.dPIEPotential.convergence_2d_from` — previously returned `aa.VectorYX2D` (wrong wrapper from a copy-paste of the deflections decorator); now returns `aa.Array2D` matching the corresponding `dPIEPotentialSph.convergence_2d_from` already in the same file.

### Added (tests only)
- `test_autogalaxy/profiles/test_basis.py::test__image_2d_from__returns_array2d_for_linear_only_basis` — regression test for the Basis fix.
- `test_autogalaxy/profiles/mass/total/test_dual_pseudo_isothermal_potential.py::test__convergence_2d_from__returns_array2d_not_vector` — regression test for the dPIEPotential fix.

### Removed / Renamed / Changed Signature / Changed Behaviour / Migration
- None — public API surface unchanged. Internal implementation now matches the documented return types.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)