### PR TITLE
feat(galaxy): named-galaxy CSV reader/writer for full model round-trips

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -87,6 +87,12 @@ from .galaxy.galaxies import Galaxies
 from .galaxy.galaxy_table import GalaxyTable
 from .galaxy.galaxy_table import galaxy_table_from_csv
 from .galaxy.galaxy_table import galaxy_table_to_csv
+from .galaxy.galaxy_model_csv import GalaxyModelRow
+from .galaxy.galaxy_model_csv import GalaxyModelTable
+from .galaxy.galaxy_model_csv import galaxy_models_from_csv
+from .galaxy.galaxy_model_csv import galaxy_models_to_csv
+from .galaxy.galaxy_model_csv import galaxies_from_csv_tables
+from .galaxy.galaxy_model_csv import galaxy_af_models_from_csv_tables
 from .galaxy.redshift import Redshift
 from .galaxy.to_inversion import AbstractToInversion
 from .galaxy.to_inversion import GalaxiesToInversion

--- a/autogalaxy/galaxy/galaxy_model_csv.py
+++ b/autogalaxy/galaxy/galaxy_model_csv.py
@@ -154,10 +154,21 @@ def galaxy_models_to_csv(
             f"family must be one of {sorted(_FAMILY_NAMESPACES)}, got '{family}'."
         )
 
+    namespace = _FAMILY_NAMESPACES[family]
+
     rows: List[dict] = []
     for galaxy_name, attr_dict in profiles_by_galaxy.items():
         for attr_name, profile in attr_dict.items():
             cls = type(profile)
+            if getattr(namespace, cls.__name__, None) is not cls:
+                raise ValueError(
+                    f"Profile {galaxy_name!r}.{attr_name!r} has class "
+                    f"{cls.__name__!r} which is not exposed in family "
+                    f"namespace '{namespace.__name__}' (family '{family}'). "
+                    f"Check that the profile belongs to the family declared "
+                    f"on this CSV — mass profiles go in 'mass', light profiles "
+                    f"in 'light', point sources in 'point'."
+                )
             row: Dict[str, Any] = {
                 "galaxy": galaxy_name,
                 "attr_name": attr_name,

--- a/autogalaxy/galaxy/galaxy_model_csv.py
+++ b/autogalaxy/galaxy/galaxy_model_csv.py
@@ -1,0 +1,329 @@
+"""
+Named-galaxy CSV reader/writer for the PyAuto ecosystem.
+
+Where ``galaxy_table.py`` covers a flat ``y, x, luminosity`` schema for the
+scaling-relation tier, this module covers the *full model* — each row carries a
+galaxy name, an attribute name (e.g. ``mass``, ``bulge``, ``point_0``), a
+``profile_class`` string, and the constructor parameters of that profile.
+Multiple family-level CSVs (mass / light / point) can be joined on the
+``galaxy`` column to compose a full ``Galaxy`` (or ``af.Model[Galaxy]``).
+
+The schema is sparse: a single CSV can carry rows of different profile classes
+with disjoint constructor parameters; cells for parameters the row's class
+does not use are blank.
+
+Profile-class dispatch goes through three family namespaces inside
+:mod:`autogalaxy`:
+
+  - ``mass``  → :mod:`autogalaxy.profiles.mass`
+  - ``light`` → :mod:`autogalaxy.profiles.light.standard`
+  - ``point`` → :mod:`autogalaxy.profiles.point_sources`
+
+The module stays inside :mod:`autogalaxy`; PyAutoLens re-exports the public
+helpers under ``al.*`` so workspace scripts can use the canonical namespace.
+"""
+import inspect
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from autoconf import csvable
+
+from autogalaxy.galaxy.galaxy import Galaxy
+from autogalaxy.profiles import mass as _mp_module
+from autogalaxy.profiles.light import standard as _lp_module
+from autogalaxy.profiles import point_sources as _ps_module
+
+
+_FAMILY_NAMESPACES = {
+    "mass": _mp_module,
+    "light": _lp_module,
+    "point": _ps_module,
+}
+
+
+_TUPLE_PARAM_COL_NAMES = {
+    "centre": ("y", "x"),
+}
+
+
+_FIXED_HEADERS = ("galaxy", "attr_name", "profile_class")
+_REDSHIFT_HEADER = "redshift"
+
+
+@dataclass
+class GalaxyModelRow:
+    """
+    A single CSV row resolved to its concrete profile class + constructor kwargs.
+
+    ``params`` only contains the columns the row's ``profile_class`` actually
+    consumes; blank cells are dropped so the profile class falls back to its
+    own default values.
+    """
+
+    galaxy: str
+    attr_name: str
+    profile_class: type
+    params: Dict[str, Any] = field(default_factory=dict)
+    redshift: Optional[float] = None
+
+
+@dataclass
+class GalaxyModelTable:
+    """
+    A typed view onto one family CSV (mass / light / point).
+    """
+
+    rows: List[GalaxyModelRow]
+    family: str
+
+
+def _profile_init_params(cls):
+    """Yield ``(name, default)`` for each constructor parameter of ``cls`` except ``self``."""
+    sig = inspect.signature(cls)
+    for name, parameter in sig.parameters.items():
+        if parameter.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        default = (
+            parameter.default
+            if parameter.default is not inspect.Parameter.empty
+            else None
+        )
+        yield name, default
+
+
+def _is_tuple_param(default) -> bool:
+    return isinstance(default, tuple)
+
+
+def _tuple_col_names(param_name: str):
+    if param_name in _TUPLE_PARAM_COL_NAMES:
+        return _TUPLE_PARAM_COL_NAMES[param_name]
+    return (f"{param_name}_0", f"{param_name}_1")
+
+
+def _coerce_scalar(value):
+    """Coerce a CSV cell string to float when possible, else return as-is."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return value
+    return value
+
+
+def galaxy_models_to_csv(
+    profiles_by_galaxy: Dict[str, Dict[str, Any]],
+    file_path: Union[str, Path],
+    family: str,
+    redshifts: Optional[Dict[str, float]] = None,
+) -> None:
+    """
+    Write a family of profiles to ``file_path`` as a CSV.
+
+    Parameters
+    ----------
+    profiles_by_galaxy
+        Mapping ``{galaxy_name: {attr_name: profile_instance}}``. Each
+        ``profile_instance`` is a concrete ``LightProfile`` / ``MassProfile`` /
+        ``PointSource``; its ``__init__`` constructor arguments are introspected
+        via :func:`inspect.signature` and emitted as columns.
+    file_path
+        Destination CSV path. Parent directories are created if missing.
+    family
+        One of ``"mass"``, ``"light"``, ``"point"`` — used as a label only;
+        no validation against the class namespaces happens on write.
+    redshifts
+        Optional ``{galaxy_name: redshift}`` mapping. When provided, every row
+        for that galaxy carries the redshift in the ``redshift`` column.
+
+    Notes
+    -----
+    Sparse columns are supported: if galaxies use different profile classes
+    with non-overlapping constructor parameters, the header line is the union
+    of all parameter columns seen, with blank cells where a row's class does
+    not use a column.
+    """
+    if family not in _FAMILY_NAMESPACES:
+        raise ValueError(
+            f"family must be one of {sorted(_FAMILY_NAMESPACES)}, got '{family}'."
+        )
+
+    rows: List[dict] = []
+    for galaxy_name, attr_dict in profiles_by_galaxy.items():
+        for attr_name, profile in attr_dict.items():
+            cls = type(profile)
+            row: Dict[str, Any] = {
+                "galaxy": galaxy_name,
+                "attr_name": attr_name,
+                "profile_class": cls.__name__,
+            }
+            for param_name, default in _profile_init_params(cls):
+                value = getattr(profile, param_name, None)
+                if value is None:
+                    continue
+                if _is_tuple_param(default):
+                    col0, col1 = _tuple_col_names(param_name)
+                    row[col0] = float(value[0])
+                    row[col1] = float(value[1])
+                else:
+                    row[param_name] = float(value) if isinstance(value, (int, float)) else value
+            if redshifts is not None and galaxy_name in redshifts:
+                row[_REDSHIFT_HEADER] = float(redshifts[galaxy_name])
+            rows.append(row)
+
+    headers = list(_FIXED_HEADERS)
+    seen = set(headers)
+    for row in rows:
+        for key in row:
+            if key not in seen and key != _REDSHIFT_HEADER:
+                seen.add(key)
+                headers.append(key)
+    if any(_REDSHIFT_HEADER in r for r in rows):
+        headers.append(_REDSHIFT_HEADER)
+
+    csvable.output_to_csv(rows, file_path, headers=headers)
+
+
+def galaxy_models_from_csv(
+    file_path: Union[str, Path],
+    family: str,
+) -> GalaxyModelTable:
+    """
+    Read a family CSV produced by :func:`galaxy_models_to_csv`.
+
+    Parameters
+    ----------
+    file_path
+        Path to the CSV file. An empty CSV (no header line) and a header-only
+        CSV both return an empty :class:`GalaxyModelTable`.
+    family
+        One of ``"mass"``, ``"light"``, ``"point"``. Selects the namespace
+        the ``profile_class`` column is looked up against.
+
+    Raises
+    ------
+    ValueError
+        If ``family`` is not one of the supported names, or if a row's
+        ``profile_class`` does not exist in the family namespace.
+    """
+    if family not in _FAMILY_NAMESPACES:
+        raise ValueError(
+            f"family must be one of {sorted(_FAMILY_NAMESPACES)}, got '{family}'."
+        )
+
+    namespace = _FAMILY_NAMESPACES[family]
+    raw_rows = csvable.list_from_csv(file_path)
+
+    parsed: List[GalaxyModelRow] = []
+    for raw in raw_rows:
+        cls_name = raw["profile_class"]
+        cls = getattr(namespace, cls_name, None)
+        if cls is None:
+            raise ValueError(
+                f"profile_class '{cls_name}' not found in namespace "
+                f"'{namespace.__name__}' (family '{family}'). Verify the class "
+                f"name is spelled correctly and exposed in that namespace."
+            )
+
+        params: Dict[str, Any] = {}
+        for param_name, default in _profile_init_params(cls):
+            if _is_tuple_param(default):
+                col0, col1 = _tuple_col_names(param_name)
+                v0, v1 = raw.get(col0), raw.get(col1)
+                if v0 not in ("", None) and v1 not in ("", None):
+                    params[param_name] = (float(v0), float(v1))
+            else:
+                v = raw.get(param_name)
+                if v not in ("", None):
+                    params[param_name] = _coerce_scalar(v)
+
+        rz_raw = raw.get(_REDSHIFT_HEADER)
+        redshift = float(rz_raw) if rz_raw not in ("", None) else None
+
+        parsed.append(
+            GalaxyModelRow(
+                galaxy=raw["galaxy"],
+                attr_name=raw["attr_name"],
+                profile_class=cls,
+                params=params,
+                redshift=redshift,
+            )
+        )
+
+    return GalaxyModelTable(rows=parsed, family=family)
+
+
+def _group_rows_by_galaxy(*tables: GalaxyModelTable) -> Dict[str, List[GalaxyModelRow]]:
+    by_galaxy: Dict[str, List[GalaxyModelRow]] = {}
+    for table in tables:
+        for row in table.rows:
+            by_galaxy.setdefault(row.galaxy, []).append(row)
+    return by_galaxy
+
+
+def _resolve_redshift(galaxy_name: str, rows: List[GalaxyModelRow]) -> Optional[float]:
+    redshifts = {row.redshift for row in rows if row.redshift is not None}
+    if len(redshifts) > 1:
+        raise ValueError(
+            f"Galaxy '{galaxy_name}' has inconsistent redshifts across CSV rows: "
+            f"{sorted(redshifts)}. All rows for a given galaxy must share the same "
+            f"redshift (or all leave it blank)."
+        )
+    return next(iter(redshifts)) if redshifts else None
+
+
+def galaxies_from_csv_tables(*tables: GalaxyModelTable) -> Dict[str, Galaxy]:
+    """
+    Combine one or more family tables into concrete ``Galaxy`` instances.
+
+    Rows are joined on the ``galaxy`` column; each galaxy's profile attributes
+    are attached under their ``attr_name``. Per-galaxy redshifts must be
+    consistent across every CSV row for that galaxy (or all blank).
+
+    Returns
+    -------
+    Mapping ``{galaxy_name: Galaxy}`` preserving the first-seen order across
+    the input tables.
+    """
+    by_galaxy = _group_rows_by_galaxy(*tables)
+
+    galaxies: Dict[str, Galaxy] = {}
+    for galaxy_name, rows in by_galaxy.items():
+        redshift = _resolve_redshift(galaxy_name, rows)
+        attrs = {row.attr_name: row.profile_class(**row.params) for row in rows}
+        galaxies[galaxy_name] = Galaxy(redshift=redshift, **attrs)
+
+    return galaxies
+
+
+def galaxy_af_models_from_csv_tables(*tables: GalaxyModelTable) -> Dict[str, Any]:
+    """
+    Combine one or more family tables into ``af.Model[Galaxy]`` instances.
+
+    Each profile becomes an ``af.Model(profile_class, **params)`` with the
+    CSV's concrete values as fixed defaults; the returned ``af.Model[Galaxy]``
+    instances are ready to mutate (set priors on selected params) and
+    assemble into an ``af.Collection``.
+
+    Returns
+    -------
+    Mapping ``{galaxy_name: af.Model[Galaxy]}`` preserving the first-seen
+    order across the input tables.
+    """
+    import autofit as af
+
+    by_galaxy = _group_rows_by_galaxy(*tables)
+
+    galaxy_models: Dict[str, Any] = {}
+    for galaxy_name, rows in by_galaxy.items():
+        redshift = _resolve_redshift(galaxy_name, rows)
+        attrs = {row.attr_name: af.Model(row.profile_class, **row.params) for row in rows}
+        galaxy_models[galaxy_name] = af.Model(Galaxy, redshift=redshift, **attrs)
+
+    return galaxy_models

--- a/test_autogalaxy/galaxy/test_galaxy_model_csv.py
+++ b/test_autogalaxy/galaxy/test_galaxy_model_csv.py
@@ -1,0 +1,244 @@
+import csv
+
+import pytest
+
+import autofit as af
+import autogalaxy as ag
+
+
+def _read_raw_rows(file_path):
+    with open(file_path, newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def test__mass_single_class__round_trip(tmp_path):
+    file_path = tmp_path / "main_lens_mass.csv"
+
+    profiles_by_galaxy = {
+        "lens_0": {"mass": ag.mp.dPIEMassSph(centre=(0.0, 0.0), ra=8.0, rs=20.0, b0=3.0)},
+        "lens_1": {"mass": ag.mp.dPIEMassSph(centre=(10.0, 8.0), ra=5.0, rs=12.0, b0=1.2)},
+    }
+
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy=profiles_by_galaxy,
+        file_path=file_path,
+        family="mass",
+        redshifts={"lens_0": 0.5, "lens_1": 0.5},
+    )
+
+    table = ag.galaxy_models_from_csv(file_path, family="mass")
+
+    assert table.family == "mass"
+    assert [r.galaxy for r in table.rows] == ["lens_0", "lens_1"]
+    assert [r.attr_name for r in table.rows] == ["mass", "mass"]
+    assert all(r.profile_class is ag.mp.dPIEMassSph for r in table.rows)
+    assert table.rows[0].params == {"centre": (0.0, 0.0), "ra": 8.0, "rs": 20.0, "b0": 3.0}
+    assert table.rows[0].redshift == 0.5
+
+
+def test__mass_sparse_columns__dpie_plus_nfw__round_trip(tmp_path):
+    file_path = tmp_path / "main_lens_mass.csv"
+
+    profiles_by_galaxy = {
+        "lens_0": {"mass": ag.mp.dPIEMassSph(centre=(0.0, 0.0), ra=8.0, rs=20.0, b0=3.0)},
+        "host_halo": {
+            "dark": ag.mp.NFWMCRLudlowSph(
+                centre=(0.0, 0.0),
+                mass_at_200=1.99e15,
+                redshift_object=0.5,
+                redshift_source=2.0,
+            )
+        },
+    }
+
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy=profiles_by_galaxy,
+        file_path=file_path,
+        family="mass",
+        redshifts={"lens_0": 0.5, "host_halo": 0.5},
+    )
+
+    raw_rows = _read_raw_rows(file_path)
+    assert set(raw_rows[0].keys()).issuperset(
+        {"galaxy", "attr_name", "profile_class", "y", "x", "ra", "rs", "b0",
+         "mass_at_200", "redshift_object", "redshift_source", "redshift"}
+    )
+    # dPIE row leaves NFW-only columns blank.
+    assert raw_rows[0]["galaxy"] == "lens_0"
+    assert raw_rows[0]["mass_at_200"] == ""
+    assert raw_rows[0]["redshift_object"] == ""
+    # NFW row leaves dPIE-only columns blank.
+    assert raw_rows[1]["galaxy"] == "host_halo"
+    assert raw_rows[1]["ra"] == ""
+    assert raw_rows[1]["b0"] == ""
+
+    table = ag.galaxy_models_from_csv(file_path, family="mass")
+    assert table.rows[0].profile_class is ag.mp.dPIEMassSph
+    assert table.rows[0].params == {"centre": (0.0, 0.0), "ra": 8.0, "rs": 20.0, "b0": 3.0}
+    assert table.rows[1].profile_class is ag.mp.NFWMCRLudlowSph
+    assert table.rows[1].params == {
+        "centre": (0.0, 0.0),
+        "mass_at_200": 1.99e15,
+        "redshift_object": 0.5,
+        "redshift_source": 2.0,
+    }
+
+
+def test__light_family__sersic_sph_plus_sersic_core__round_trip(tmp_path):
+    file_path = tmp_path / "light.csv"
+
+    profiles_by_galaxy = {
+        "lens_0": {"bulge": ag.lp.SersicSph(centre=(0.0, 0.0), intensity=1.5, effective_radius=3.0, sersic_index=4.0)},
+        "source_0": {
+            "bulge": ag.lp.SersicCore(
+                centre=(0.3, 0.5),
+                ell_comps=(0.1, -0.2),
+                intensity=2.0,
+                effective_radius=0.3,
+                sersic_index=1.0,
+            )
+        },
+    }
+
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy=profiles_by_galaxy,
+        file_path=file_path,
+        family="light",
+    )
+
+    table = ag.galaxy_models_from_csv(file_path, family="light")
+    assert table.rows[0].profile_class is ag.lp.SersicSph
+    assert table.rows[0].params["centre"] == (0.0, 0.0)
+    assert "ell_comps" not in table.rows[0].params  # SersicSph has no ell_comps
+    assert table.rows[1].profile_class is ag.lp.SersicCore
+    assert table.rows[1].params["ell_comps"] == (0.1, -0.2)
+
+
+def test__point_family__round_trip(tmp_path):
+    file_path = tmp_path / "source_point.csv"
+
+    profiles_by_galaxy = {
+        "source_0": {"point_0": ag.ps.Point(centre=(0.3, 0.5))},
+        "source_1": {"point_1": ag.ps.Point(centre=(-0.8, 1.2))},
+    }
+
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy=profiles_by_galaxy,
+        file_path=file_path,
+        family="point",
+        redshifts={"source_0": 1.0, "source_1": 2.0},
+    )
+
+    table = ag.galaxy_models_from_csv(file_path, family="point")
+    assert [r.attr_name for r in table.rows] == ["point_0", "point_1"]
+    assert all(r.profile_class is ag.ps.Point for r in table.rows)
+    assert table.rows[0].params["centre"] == (0.3, 0.5)
+    assert table.rows[1].redshift == 2.0
+
+
+def test__cross_family_join__builds_named_galaxies(tmp_path):
+    mass_csv = tmp_path / "mass.csv"
+    light_csv = tmp_path / "light.csv"
+    point_csv = tmp_path / "point.csv"
+
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy={
+            "lens_0": {"mass": ag.mp.dPIEMassSph(centre=(0.0, 0.0), ra=8.0, rs=20.0, b0=3.0)},
+        },
+        file_path=mass_csv,
+        family="mass",
+        redshifts={"lens_0": 0.5},
+    )
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy={
+            "lens_0": {"bulge": ag.lp.SersicSph(centre=(0.0, 0.0), intensity=1.5, effective_radius=3.0, sersic_index=4.0)},
+            "source_0": {"bulge": ag.lp.SersicCore(centre=(0.3, 0.5), ell_comps=(0.1, -0.2), intensity=2.0, effective_radius=0.3, sersic_index=1.0)},
+        },
+        file_path=light_csv,
+        family="light",
+        redshifts={"lens_0": 0.5, "source_0": 1.0},
+    )
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy={
+            "source_0": {"point_0": ag.ps.Point(centre=(0.3, 0.5))},
+        },
+        file_path=point_csv,
+        family="point",
+        redshifts={"source_0": 1.0},
+    )
+
+    galaxies = ag.galaxies_from_csv_tables(
+        ag.galaxy_models_from_csv(mass_csv, family="mass"),
+        ag.galaxy_models_from_csv(light_csv, family="light"),
+        ag.galaxy_models_from_csv(point_csv, family="point"),
+    )
+
+    assert set(galaxies.keys()) == {"lens_0", "source_0"}
+    assert galaxies["lens_0"].redshift == 0.5
+    assert isinstance(galaxies["lens_0"].mass, ag.mp.dPIEMassSph)
+    assert isinstance(galaxies["lens_0"].bulge, ag.lp.SersicSph)
+    assert galaxies["source_0"].redshift == 1.0
+    assert isinstance(galaxies["source_0"].bulge, ag.lp.SersicCore)
+    assert isinstance(galaxies["source_0"].point_0, ag.ps.Point)
+
+
+def test__af_models_round_trip(tmp_path):
+    mass_csv = tmp_path / "mass.csv"
+
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy={
+            "lens_0": {"mass": ag.mp.dPIEMassSph(centre=(0.0, 0.0), ra=8.0, rs=20.0, b0=3.0)},
+        },
+        file_path=mass_csv,
+        family="mass",
+        redshifts={"lens_0": 0.5},
+    )
+
+    galaxy_models = ag.galaxy_af_models_from_csv_tables(
+        ag.galaxy_models_from_csv(mass_csv, family="mass"),
+    )
+
+    assert "lens_0" in galaxy_models
+    galaxy_model = galaxy_models["lens_0"]
+    assert isinstance(galaxy_model, af.Model)
+    assert galaxy_model.cls is ag.Galaxy
+    assert galaxy_model.redshift == 0.5
+    assert galaxy_model.mass.cls is ag.mp.dPIEMassSph
+    assert galaxy_model.mass.ra == 8.0
+    assert galaxy_model.mass.rs == 20.0
+    assert galaxy_model.mass.b0 == 3.0
+
+
+def test__redshift_consistency_check__raises(tmp_path):
+    mass_csv = tmp_path / "mass.csv"
+    light_csv = tmp_path / "light.csv"
+
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy={"lens_0": {"mass": ag.mp.dPIEMassSph(centre=(0.0, 0.0), ra=8.0, rs=20.0, b0=3.0)}},
+        file_path=mass_csv,
+        family="mass",
+        redshifts={"lens_0": 0.5},
+    )
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy={"lens_0": {"bulge": ag.lp.SersicSph(centre=(0.0, 0.0), intensity=1.5, effective_radius=3.0, sersic_index=4.0)}},
+        file_path=light_csv,
+        family="light",
+        redshifts={"lens_0": 0.7},
+    )
+
+    with pytest.raises(ValueError, match="inconsistent redshifts"):
+        ag.galaxies_from_csv_tables(
+            ag.galaxy_models_from_csv(mass_csv, family="mass"),
+            ag.galaxy_models_from_csv(light_csv, family="light"),
+        )
+
+
+def test__class_not_found_in_namespace__raises(tmp_path):
+    file_path = tmp_path / "mass.csv"
+    file_path.write_text(
+        "galaxy,attr_name,profile_class,y,x\n"
+        "lens_0,mass,NotARealClass,0.0,0.0\n"
+    )
+
+    with pytest.raises(ValueError, match="profile_class 'NotARealClass' not found"):
+        ag.galaxy_models_from_csv(file_path, family="mass")

--- a/test_autogalaxy/galaxy/test_galaxy_model_csv.py
+++ b/test_autogalaxy/galaxy/test_galaxy_model_csv.py
@@ -233,6 +233,20 @@ def test__redshift_consistency_check__raises(tmp_path):
         )
 
 
+def test__writer_rejects_profile_from_wrong_family(tmp_path):
+    """Writing a SersicSph (light) under family='mass' must raise immediately."""
+    file_path = tmp_path / "mass.csv"
+
+    with pytest.raises(ValueError, match="not exposed in family namespace"):
+        ag.galaxy_models_to_csv(
+            profiles_by_galaxy={
+                "lens_0": {"bulge": ag.lp.SersicSph(centre=(0.0, 0.0), intensity=1.0, effective_radius=1.0, sersic_index=2.0)},
+            },
+            file_path=file_path,
+            family="mass",
+        )
+
+
 def test__class_not_found_in_namespace__raises(tmp_path):
     file_path = tmp_path / "mass.csv"
     file_path.write_text(


### PR DESCRIPTION
## Summary

Adds a CSV layer over the full galaxy model — names, profile classes, and constructor parameters — so cluster modelling scripts can store and reload an entire `af.Collection` of `Galaxy` objects as a small set of human-editable CSVs. Sibling of the existing `galaxy_table.py` (which keeps its narrow `y, x, luminosity` scaling-tier schema unchanged).

Workspace integration follows in a separate PR on `autolens_workspace` (issue [PyAutoLabs/autolens_workspace#187](https://github.com/PyAutoLabs/autolens_workspace/issues/187)) — this PR is library helpers + tests only.

## API Changes

Two new public dataclasses (`GalaxyModelRow`, `GalaxyModelTable`) and four public functions (`galaxy_models_to_csv`, `galaxy_models_from_csv`, `galaxies_from_csv_tables`, `galaxy_af_models_from_csv_tables`). One CSV per profile family (`mass` / `light` / `point`); profile classes dispatch via `getattr` against `autogalaxy.profiles.{mass,light.standard,point_sources}`. Sparse columns supported — disparate profile classes can share one CSV.

No breaking changes. `galaxy_table.py` is untouched.

See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/galaxy/test_galaxy_model_csv.py` — 8 new tests cover single-family round-trip, sparse-column round-trip (dPIE + NFW), light family (Sersic + SersicCore), point family, cross-family join, `af.Model` round-trip, redshift-consistency check, class-not-found error.
- [x] `pytest test_autogalaxy/galaxy/` — 100 passing, no regressions.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- `autogalaxy.GalaxyModelRow` — dataclass: `galaxy: str, attr_name: str, profile_class: type, params: Dict[str, Any], redshift: Optional[float]`.
- `autogalaxy.GalaxyModelTable` — dataclass: `rows: List[GalaxyModelRow], family: str`.
- `autogalaxy.galaxy_models_to_csv(profiles_by_galaxy, file_path, family, redshifts=None)` — writes a family CSV with one row per (galaxy, attr_name) pair. Introspects each profile instance's constructor via `inspect.signature` to discover the column set; sparse columns supported (different profile classes can share one CSV).
- `autogalaxy.galaxy_models_from_csv(file_path, family)` — reads a family CSV and dispatches `profile_class` against `autogalaxy.profiles.{mass,light.standard,point_sources}` for `family ∈ {"mass", "light", "point"}` respectively. Returns a typed `GalaxyModelTable`.
- `autogalaxy.galaxies_from_csv_tables(*tables)` — joins one or more `GalaxyModelTable`s on the `galaxy` column and returns `Dict[str, Galaxy]`. Per-galaxy redshift consistency is enforced.
- `autogalaxy.galaxy_af_models_from_csv_tables(*tables)` — same as above but returns `Dict[str, af.Model[Galaxy]]` with concrete CSV values as fixed `af.Model` defaults (ready to mutate selected params into priors).

### CSV schema

- Fixed columns: `galaxy, attr_name, profile_class`.
- `centre` tuple param → `y, x` columns (precedent from `galaxy_table.py`).
- Other tuple params (e.g. `ell_comps`) → `<name>_0, <name>_1` columns.
- Optional `redshift` column for per-galaxy redshift (consistent across rows for the same galaxy or all blank).

### Module

- New file: `autogalaxy/galaxy/galaxy_model_csv.py` (~280 lines).
- Existing `autogalaxy/galaxy/galaxy_table.py` unchanged.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)