### PR TITLE
fix(csv): preserve TuplePrior on af.Model built from tuple-param rows

### DIFF
--- a/autogalaxy/galaxy/galaxy_model_csv.py
+++ b/autogalaxy/galaxy/galaxy_model_csv.py
@@ -334,7 +334,16 @@ def galaxy_af_models_from_csv_tables(*tables: GalaxyModelTable) -> Dict[str, Any
     galaxy_models: Dict[str, Any] = {}
     for galaxy_name, rows in by_galaxy.items():
         redshift = _resolve_redshift(galaxy_name, rows)
-        attrs = {row.attr_name: af.Model(row.profile_class, **row.params) for row in rows}
+        attrs: Dict[str, Any] = {}
+        for row in rows:
+            model = af.Model(row.profile_class)
+            for name, value in row.params.items():
+                if isinstance(value, tuple):
+                    for i, component in enumerate(value):
+                        setattr(model, f"{name}_{i}", component)
+                else:
+                    setattr(model, name, value)
+            attrs[row.attr_name] = model
         galaxy_models[galaxy_name] = af.Model(Galaxy, redshift=redshift, **attrs)
 
     return galaxy_models

--- a/test_autogalaxy/galaxy/test_galaxy_model_csv.py
+++ b/test_autogalaxy/galaxy/test_galaxy_model_csv.py
@@ -209,6 +209,30 @@ def test__af_models_round_trip(tmp_path):
     assert galaxy_model.mass.b0 == 3.0
 
 
+def test__af_models__tuple_param_supports_prior_override(tmp_path):
+    point_csv = tmp_path / "point.csv"
+
+    ag.galaxy_models_to_csv(
+        profiles_by_galaxy={"source_0": {"point_0": ag.ps.Point(centre=(0.3, 0.5))}},
+        file_path=point_csv,
+        family="point",
+        redshifts={"source_0": 1.0},
+    )
+
+    galaxy_models = ag.galaxy_af_models_from_csv_tables(
+        ag.galaxy_models_from_csv(point_csv, family="point"),
+    )
+
+    point_attr = galaxy_models["source_0"].point_0
+    point_attr.centre_0 = af.GaussianPrior(mean=0.3, sigma=3.0)
+    point_attr.centre_1 = af.GaussianPrior(mean=0.5, sigma=3.0)
+
+    instance = galaxy_models["source_0"].instance_from_unit_vector([0.5, 0.5])
+    assert isinstance(instance.point_0, ag.ps.Point)
+    assert isinstance(instance.point_0.centre, tuple)
+    assert len(instance.point_0.centre) == 2
+
+
 def test__redshift_consistency_check__raises(tmp_path):
     mass_csv = tmp_path / "mass.csv"
     light_csv = tmp_path / "light.csv"


### PR DESCRIPTION
## Summary
`galaxy_af_models_from_csv_tables` previously built each profile's `af.Model`
with `af.Model(cls, **params)`. For tuple-valued params (e.g. `centre=(0.3, 0.5)`)
this bypassed PyAutoFit's `TuplePrior` auto-create path (in
`autofit/mapper/prior_model/prior_model.py:144-156` the tuple branch only fires
for defaults, not kwargs) and stored `centre` as a raw tuple attribute. Later
overrides like `model.centre_0 = af.GaussianPrior(...)` then created **ghost
direct attributes** alongside the raw tuple, because `PriorModel.__setattr__`
falls through to `super().__setattr__` when no matching `TuplePrior` is found.
At sample time, `_instance_for_arguments` called
`Point(centre=(0.3, 0.5), centre_0=..., centre_1=...)` and the search crashed
with `TypeError: Point.__init__() got an unexpected keyword argument 'centre_0'`.

The fix builds `af.Model(cls)` with no kwargs first — this triggers the
auto-create-`TuplePrior` branch for tuple-defaulted ctor args — and then sets
each tuple param component-wise via `setattr(model, f"{name}_{i}", component)`.
Scalar params are unchanged. Later prior overrides on `.centre_0` / `.centre_1`
now delegate correctly into the existing `TuplePrior`.

Unblocks `autolens_workspace/scripts/cluster/start_here.py` and
`autolens_workspace/scripts/cluster/modeling.py`, which crashed on every run
after the recent cluster-CSV API adoption.

## API Changes
None — internal change to the construction logic inside
`galaxy_af_models_from_csv_tables`. Existing callers that don't override
tuple-component priors after construction see no behaviour difference; callers
that *do* (the cluster modeling scripts) now succeed instead of raising
`TypeError` at sample time.
See full details below.

## Test Plan
- [x] `pytest test_autogalaxy/galaxy/test_galaxy_model_csv.py -v` — 10/10 pass, including new regression test `test__af_models__tuple_param_supports_prior_override` that exercises the failing pattern end-to-end (CSV → `af.Model` → `centre_0/1` GaussianPrior override → `instance_from_unit_vector`)
- [x] `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1 python autolens_workspace/scripts/cluster/start_here.py` — runs to completion
- [x] `PYAUTO_TEST_MODE=2 ... python autolens_workspace/scripts/cluster/modeling.py` — runs to completion

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
None.

### Added
None.

### Changed Behaviour
- `galaxy_af_models_from_csv_tables(*tables)` — the returned `af.Model` instances now carry a `TuplePrior` for tuple-valued attributes (e.g. `centre`) rather than a raw `tuple`. Reading `model.centre` is unchanged for downstream consumers (the TuplePrior resolves to a tuple at instance construction); `_0`/`_1` component overrides such as `model.centre_0 = af.GaussianPrior(...)` now delegate into the `TuplePrior` instead of creating ghost direct attributes alongside the raw tuple.

### Migration
No migration required. The previously-broken `.centre_0 = prior` / `.centre_1 = prior` override pattern on a CSV-built model now works as the cluster scripts expect.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)