### PR TITLE
fix(lens_calc): preserve evaluation_grid extent under PYAUTO_SMALL_DATASETS=1

### DIFF
--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -87,6 +87,7 @@ def evaluation_grid(func):
             shape_native=shape_native,
             pixel_scales=(pixel_scale, pixel_scale),
             origin=zoom.offset_scaled,
+            respect_small_datasets=False,
         )
 
         grid.is_evaluation_grid = True

--- a/test_autogalaxy/operate/test_deflections.py
+++ b/test_autogalaxy/operate/test_deflections.py
@@ -189,6 +189,22 @@ def test__tangential_critical_curve_list_from__centre_at_origin__curve_centred_o
     assert -0.03 < x_centre < 0.03
 
 
+def test__tangential_critical_curve_list_from__small_datasets_env__evaluation_grid_keeps_extent(
+    monkeypatch,
+):
+    monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
+
+    grid = ag.Grid2D.uniform(
+        shape_native=(200, 200), pixel_scales=0.2, respect_small_datasets=False
+    )
+    mp = ag.mp.IsothermalSph(centre=(0.0, 0.0), einstein_radius=10.0)
+
+    od = LensCalc.from_mass_obj(mp)
+    tangential_critical_curve_list = od.tangential_critical_curve_list_from(grid=grid)
+
+    assert len(tangential_critical_curve_list) == 1
+
+
 def test__tangential_critical_curve_list_from__offset_centre__curve_centred_on_offset():
     grid = ag.Grid2D.uniform(shape_native=(50, 50), pixel_scales=0.2)
 


### PR DESCRIPTION
## Summary
Threads `respect_small_datasets=False` into the internal `Grid2D.uniform` call inside the `evaluation_grid` decorator (`autogalaxy/operate/lens_calc.py:86`). Restores correct behaviour of all `LensCalc` critical-curve / caustic / area methods under `PYAUTO_SMALL_DATASETS=1` smoke mode.

Without this fix, `tangential_critical_curve_list_from` (and siblings) silently return `[]` in smoke mode for any lens whose critical curve falls outside a ~8" extent — including all cluster-scale lenses, plus any galaxy-scale model whose user grid is centred away from the origin. The decorator's job is to *preserve user-requested spatial extent at finer resolution*; the autoarray shrink defeated that universally.

**Depends on the companion PyAutoArray PR** (adds the `respect_small_datasets` kwarg this PR uses). Merge the PyAutoArray PR first; CI here will fail until that lands.

## API Changes
None — internal change only. Public `LensCalc.tangential_critical_curve_list_from`, `radial_critical_curve_list_from`, caustic and area variants now correctly return curves under `PYAUTO_SMALL_DATASETS=1` (previously returned `[]`).
See full details below.

## Test Plan
- [x] `pytest test_autogalaxy/operate/test_deflections.py` — all tests pass, including new `test__tangential_critical_curve_list_from__small_datasets_env__evaluation_grid_keeps_extent`.
- [x] Manual end-to-end: `scripts/cluster/visualization.py` in `autolens_workspace_test` under `PYAUTO_SMALL_DATASETS=1` recovers `tangential_curves recovered: 1 OK`.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `LensCalc.tangential_critical_curve_list_from`, `radial_critical_curve_list_from`, `tangential_caustic_list_from`, `radial_caustic_list_from`, `tangential_critical_curve_area_list_from`, `radial_critical_curve_area_list_from` — under `PYAUTO_SMALL_DATASETS=1`, the evaluation grid is no longer silently shrunk to 15x15 @ 0.6". Methods now correctly return curves when the user's requested grid extent demands them. Behaviour outside smoke mode is unchanged.

### Internal
- `evaluation_grid` decorator in `autogalaxy/operate/lens_calc.py` now passes `respect_small_datasets=False` to its internal `Grid2D.uniform` call.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)