### PR TITLE
perf(lens_calc): cache (f, ZeroSolver) for zero_contour critical curves

### DIFF
--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -119,6 +119,10 @@ class LensCalc:
     def __init__(self, deflections_yx_2d_from, potential_2d_from=None):
         self.deflections_yx_2d_from = deflections_yx_2d_from
         self.potential_2d_from = potential_2d_from
+        # Maps (kind, pixel_scales, tol, max_newton) -> (f, ZeroSolver). Lets
+        # repeat zero_contour calls reuse JAX's compile cache, since that
+        # cache is keyed on callable identity.
+        self._zero_contour_cache: dict = {}
 
     @classmethod
     def from_mass_obj(cls, mass_obj):
@@ -1164,8 +1168,18 @@ class LensCalc:
                 return []
 
         init_guess = jnp.atleast_2d(jnp.asarray(init_guess))
-        f = self._make_eigen_fn(kind=kind, pixel_scales=pixel_scales)
-        solver = ZeroSolver(tol=tol, max_newton=max_newton)
+
+        # Reuse the (f, solver) pair across calls so ZeroSolver hits its JAX
+        # compile cache. A fresh f / solver per call costs ~10s every time
+        # because the cache is keyed on callable identity.
+        cache_key = (kind, pixel_scales, tol, max_newton)
+        if cache_key not in self._zero_contour_cache:
+            self._zero_contour_cache[cache_key] = (
+                self._make_eigen_fn(kind=kind, pixel_scales=pixel_scales),
+                ZeroSolver(tol=tol, max_newton=max_newton),
+            )
+        f, solver = self._zero_contour_cache[cache_key]
+
         paths, _ = solver.zero_contour_finder(f, init_guess, delta=delta, N=N)
         paths = ZeroSolver.path_reduce(paths)
 

--- a/test_autogalaxy/operate/test_deflections.py
+++ b/test_autogalaxy/operate/test_deflections.py
@@ -560,3 +560,26 @@ def test__jacobian_from():
     assert magnification_via_jacobian == pytest.approx(
         np.array(magnification_via_hessian), rel=1e-6
     )
+
+
+def test__zero_contour_cache__starts_empty_and_is_per_instance():
+    """
+    `LensCalc._zero_contour_cache` must be initialised fresh per instance
+    so the closure cache reuse does not leak across LensCalc objects.
+    The cache stores `(f, ZeroSolver)` keyed on the call parameters; if it
+    were a class-level mutable default, mutating one instance's cache would
+    appear in every other instance.
+    """
+    mp = ag.mp.IsothermalSph(centre=(0.0, 0.0), einstein_radius=1.0)
+
+    od_a = LensCalc.from_mass_obj(mp)
+    od_b = LensCalc.from_mass_obj(mp)
+
+    assert od_a._zero_contour_cache == {}
+    assert od_b._zero_contour_cache == {}
+
+    od_a._zero_contour_cache[("tangential", (0.05, 0.05), 1e-6, 5)] = (
+        "f-stand-in",
+        "solver-stand-in",
+    )
+    assert od_b._zero_contour_cache == {}


### PR DESCRIPTION
## Summary

Fixes the closure cache-busting bug that made `zero_contour`-based critical curves and Einstein radii ~150× slower than they should be, blocking them from being a viable default for JIT'd likelihood functions.

`LensCalc._critical_curve_list_via_zero_contour` rebuilt `f = self._make_eigen_fn(...)` and `solver = ZeroSolver(...)` on every invocation. Since JAX caches compiled functions by callable identity, a fresh `f` each call meant the `ZeroSolver.zero_contour_finder` JIT-compile fired anew every time — ~10 s per call instead of the expected ~66 ms warm. With `(f, ZeroSolver)` cached on the `LensCalc` instance keyed on `(kind, pixel_scales, tol, max_newton)`, repeat calls reuse JAX's compile cache as expected.

This is the perf prerequisite for any future flip of the plotter default to `zero_contour` and for the planned Euclid latent migration off the marching-squares path. See [`PyAutoPrompt/z_features/fast_visualization.md`](https://github.com/PyAutoLabs/PyAutoPrompt/blob/main/z_features/fast_visualization.md), Phase A′.

Companion PR in PyAutoLens (`Jammy2211/PyAutoLens#527`) tightens the broad `except` that silently swallowed this class of regression on production runs.

Closes #433 (alongside the PyAutoLens companion).

## API Changes

`LensCalc` instances now carry a private `_zero_contour_cache` dict. No public API surface changes — same method names, same signatures, same return values. Behavioural change: `_critical_curve_list_via_zero_contour` reuses its closure and `ZeroSolver` across repeat calls with the same parameters.

See full details below.

## Test Plan

- [x] New unit test `test_autogalaxy/operate/test_deflections.py::test__zero_contour_cache__starts_empty_and_is_per_instance` — confirms each `LensCalc` gets a fresh cache and that mutations don't leak across instances.
- [x] `pytest test_autogalaxy/operate/` — 41 passed locally.
- [x] CPU benchmark on SIE + circular source: tangential warm 10300 ms → 67 ms, Einstein radius warm 10300 ms → 68 ms, radial warm 10303 ms → 380 ms.
- [x] `euclid_strong_lens_modeling_pipeline` smoke (6 scripts) — all PASS, posted at https://github.com/PyAutoLabs/PyAutoGalaxy/issues/433#issuecomment-4510650888.
- [x] `autolens_workspace_test/scripts/imaging/modeling_visualization_jit.py` `__Visualization Sanity__` block — passes (correctness + warm call 79 ms).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- `LensCalc._zero_contour_cache: dict` — private instance attribute, lazy-populated by `_critical_curve_list_via_zero_contour`. Maps `(kind, pixel_scales, tol, max_newton)` → `(f, ZeroSolver)`.

### Changed Signature
- None.

### Changed Behaviour
- `LensCalc._critical_curve_list_via_zero_contour(...)` — reuses cached `(f, ZeroSolver)` across calls with the same `(kind, pixel_scales, tol, max_newton)` instead of constructing fresh ones each invocation. Identical return values; warm-call latency drops from ~10 s to ~66 ms on CPU.

### Migration
- None required — transparent perf fix.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)