### PR TITLE
feat: JIT-friendly Einstein radius helper + AnalysisDataset jit latent mode

### DIFF
--- a/autogalaxy/analysis/analysis/dataset.py
+++ b/autogalaxy/analysis/analysis/dataset.py
@@ -18,6 +18,15 @@ logger.setLevel(level="INFO")
 
 
 class AnalysisDataset(Analysis):
+    # Lensing latents (e.g. effective Einstein radius via
+    # `LensCalc.einstein_radius_jit_from`) call into `jax_zero_contour.ZeroSolver`,
+    # which upstream documents as incompatible with `jax.vmap` (uses
+    # `jax.lax.cond` / `jax.lax.while_loop` for early termination). Override
+    # the PyAutoFit default from "vmap" to per-sample "jit" so the JIT cache
+    # is reused across samples without invoking vmap on the inner zero-contour
+    # primitives.
+    LATENT_BATCH_MODE = "jit"
+
     def __init__(
         self,
         dataset: Union[aa.Imaging, aa.Interferometer],

--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -1504,3 +1504,101 @@ class LensCalc:
                 max_newton=max_newton,
             )
         )
+
+    def einstein_radius_jit_from(
+        self,
+        init_guess,
+        delta: float = 0.05,
+        N: int = 500,
+        pixel_scales: Tuple[float, float] = (0.05, 0.05),
+        tol: float = 1e-6,
+        max_newton: int = 5,
+    ):
+        """
+        JIT-friendly Einstein radius from the tangential critical curve.
+
+        Designed for use inside ``jax.jit(...)`` (e.g. the per-sample latent
+        loop in ``autofit.Analysis.compute_latent_samples`` with
+        ``LATENT_BATCH_MODE='jit'``). Unlike ``einstein_radius_via_zero_contour_from``,
+        this method:
+
+        - Requires an explicit ``init_guess`` — no marching-squares seed search
+          (which would require ``skimage`` and break the JAX trace).
+        - Skips ``ZeroSolver.path_reduce`` (variable-length output, not jit-able).
+        - Computes the enclosed area directly from the raw NaN-padded paths
+          array via a JAX-vectorised shoelace formula.
+        - Returns a single scalar ``jax.Array`` (not a Python ``float``).
+
+        Do NOT combine this with ``jax.vmap`` — the underlying
+        ``jax_zero_contour.ZeroSolver.zero_contour_finder`` uses
+        ``jax.lax.cond`` / ``jax.lax.while_loop`` for early termination, which
+        upstream explicitly documents as incompatible with ``jax.vmap``. For
+        batched evaluation, wrap the caller in ``jax.jit`` and loop over
+        samples in Python (see ``Analysis.LATENT_BATCH_MODE='jit'``).
+
+        Parameters
+        ----------
+        init_guess
+            JAX or NumPy array of shape ``(n_seeds, 2)`` — seed positions
+            (y, x) near the expected critical curve. For typical galaxy-scale
+            lenses centred on the image, a single seed at ``[[1.0, 0.0]]``
+            works; for clusters or off-centre lenses pass a small fan of
+            seeds (e.g. four at cardinal positions).
+        delta
+            Arc-second step size along the contour. Forwarded to ``ZeroSolver``.
+        N
+            Maximum steps per seed direction. Forwarded to ``ZeroSolver``.
+        pixel_scales
+            Pixel scales passed to ``deflections_yx_scalar`` (used internally
+            by ``_make_eigen_fn``).
+        tol
+            Newton's method convergence tolerance.
+        max_newton
+            Maximum Newton iterations per step.
+
+        Returns
+        -------
+        jax.Array
+            Scalar Einstein radius in arc-seconds (``sqrt(area / pi)`` where
+            ``area`` is the largest enclosed area across all seeds — robust
+            to multiple seeds landing on the same critical curve).
+        """
+        try:
+            from jax_zero_contour import ZeroSolver
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "jax_zero_contour is required for einstein_radius_jit_from. "
+                "Install it with: pip install jax_zero_contour"
+            ) from exc
+        import jax.numpy as jnp
+
+        init_guess = jnp.atleast_2d(jnp.asarray(init_guess))
+
+        # Reuse the (f, ZeroSolver) pair from PR #434's cache so the warm
+        # call inside a jit-cached `compute_latent_variables` reuses JAX's
+        # compile cache.
+        cache_key = ("tangential", pixel_scales, tol, max_newton)
+        if cache_key not in self._zero_contour_cache:
+            self._zero_contour_cache[cache_key] = (
+                self._make_eigen_fn(kind="tangential", pixel_scales=pixel_scales),
+                ZeroSolver(tol=tol, max_newton=max_newton),
+            )
+        f, solver = self._zero_contour_cache[cache_key]
+
+        # `paths["path"]` has shape (n_seeds, max_steps, 2) — NaN-padded for
+        # invalid / post-termination steps. We compute the shoelace area
+        # directly on the raw array, masking NaN-padded terms to zero.
+        paths, _ = solver.zero_contour_finder(f, init_guess, delta=delta, N=N)
+        paths_arr = paths["path"]
+        y = paths_arr[..., 0]
+        x = paths_arr[..., 1]
+        y_next = jnp.roll(y, -1, axis=-1)
+        x_next = jnp.roll(x, -1, axis=-1)
+        terms = x * y_next - x_next * y
+        valid_terms = jnp.where(jnp.isfinite(terms), terms, 0.0)
+        area_per_seed = 0.5 * jnp.abs(jnp.sum(valid_terms, axis=-1))
+        # If multiple seeds landed on the same curve, each computes the same
+        # area; take the max so we don't double-count nor under-count when
+        # some seeds diverged.
+        area = jnp.max(area_per_seed)
+        return jnp.sqrt(area / jnp.pi)

--- a/test_autogalaxy/operate/test_deflections.py
+++ b/test_autogalaxy/operate/test_deflections.py
@@ -562,6 +562,47 @@ def test__jacobian_from():
     )
 
 
+def test__einstein_radius_jit_from__method_exists_with_expected_signature():
+    """
+    `LensCalc.einstein_radius_jit_from` is the JIT-friendly Einstein-radius
+    helper added for `Analysis.LATENT_BATCH_MODE='jit'` (see PyAutoFit). It
+    must remain on the class with `init_guess` as the only required
+    argument — pipelines pass a static `jnp.array([[1.0, 0.0]])` etc.
+
+    Runtime JAX behaviour is exercised in the workspace_test integration
+    suite (no JAX in library unit tests per project policy).
+    """
+    import inspect
+
+    assert hasattr(LensCalc, "einstein_radius_jit_from"), (
+        "LensCalc.einstein_radius_jit_from missing — required by "
+        "Analysis.LATENT_BATCH_MODE='jit' callers"
+    )
+    sig = inspect.signature(LensCalc.einstein_radius_jit_from)
+    params = sig.parameters
+    assert "init_guess" in params
+    assert params["init_guess"].default is inspect.Parameter.empty, (
+        "init_guess must be a required argument — there is no JAX-friendly "
+        "default (the legacy `_init_guess_from_coarse_grid` uses skimage)"
+    )
+    for kw in ("delta", "N", "pixel_scales", "tol", "max_newton"):
+        assert kw in params, f"einstein_radius_jit_from missing kwarg {kw!r}"
+
+
+def test__analysis_dataset__latent_batch_mode_is_jit():
+    """
+    PyAutoGalaxy's `AnalysisDataset` overrides PyAutoFit's default
+    `LATENT_BATCH_MODE='vmap'` to `'jit'` because lensing latents call into
+    `jax_zero_contour.ZeroSolver`, which upstream documents as vmap-
+    incompatible. Inheriting analyses (`AnalysisImaging`,
+    `AnalysisInterferometer`, the PyAutoLens variants, etc.) must therefore
+    use jit-per-sample for their latent computation.
+    """
+    from autogalaxy.analysis.analysis.dataset import AnalysisDataset
+
+    assert AnalysisDataset.LATENT_BATCH_MODE == "jit"
+
+
 def test__zero_contour_cache__starts_empty_and_is_per_instance():
     """
     `LensCalc._zero_contour_cache` must be initialised fresh per instance


### PR DESCRIPTION
## Summary

Two coupled changes that unlock JAX-mode latent computation for lensing pipelines:

1. **`LensCalc.einstein_radius_jit_from(init_guess, ...)`** — new ~95-line helper, fully JIT-friendly. Bypasses the non-jit-able pieces of the existing `einstein_radius_via_zero_contour_from`: no marching-squares seed search (`_init_guess_from_coarse_grid` uses skimage and breaks JAX trace), no `ZeroSolver.path_reduce` (upstream documents it as un-jit-able), no `float()` cast. Computes the enclosed area on the raw NaN-padded `paths` array via JAX-vectorised shoelace with `jnp.where(jnp.isfinite, ...)` masking, takes max area across seeds (robust to duplicate seeds on the same curve), returns a scalar `jax.Array`. Reuses the `(f, ZeroSolver)` cache from #434.

2. **`AnalysisDataset.LATENT_BATCH_MODE = "jit"`** — overrides PyAutoFit's default `"vmap"`. Required because both the new helper and the underlying `ZeroSolver` use `jax.lax.cond` / `jax.lax.while_loop` for early termination, which upstream explicitly documents as vmap-incompatible. All PyAutoGalaxy/PyAutoLens analysis classes inherit this override automatically.

Together these make `compute_latent_samples` with `use_jax=True` work for lensing latents — previously impossible because the only Einstein-radius computation available was `einstein_radius_via_zero_contour_from` (Python loops + variable-length lists, not jit-able) or `einstein_radius_from(grid=...)` (marching squares + not JAX-traceable).

## API Changes

Two additions to PyAutoGalaxy: a new public method `LensCalc.einstein_radius_jit_from`, and a class attribute override `AnalysisDataset.LATENT_BATCH_MODE = "jit"`. No existing API surface is modified or removed.

See full details below.

## Test Plan

- [x] New unit test: `LensCalc.einstein_radius_jit_from` exists with required `init_guess` argument and the expected kwargs (`delta`, `N`, `pixel_scales`, `tol`, `max_newton`). JAX-runtime behaviour exercised in the workspace integration (no JAX in library unit tests per project policy).
- [x] New unit test: `AnalysisDataset.LATENT_BATCH_MODE == "jit"`.
- [x] `pytest test_autogalaxy/operate/ test_autogalaxy/analysis/` — 78 passed locally.
- [x] End-to-end on the Euclid pipeline workspace (`euclid_strong_lens_modeling_pipeline` start_here.py under `PYAUTO_TEST_MODE=1`): latent.effective_einstein_radius = 2.1002 arcsec on the prior-median MGE tracer. ~480 ms/sample on CPU after the ~10 s first-sample compile.
- [x] Pipeline numpy-branch smoke (`PYAUTO_DISABLE_JAX=1`): 6/6 PASS — no regression on the legacy path.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `LensCalc.einstein_radius_jit_from(init_guess, delta=0.05, N=500, pixel_scales=(0.05, 0.05), tol=1e-6, max_newton=5) -> jax.Array` — JIT-friendly Einstein radius via zero-contour. Takes a static `init_guess` of shape `(n_seeds, 2)`, returns a scalar `jax.Array`. Designed for use inside `jax.jit(...)` per-sample; do NOT combine with `jax.vmap` (upstream `jax_zero_contour.ZeroSolver` uses `lax.cond` / `lax.while_loop` not safe under vmap).
- `AnalysisDataset.LATENT_BATCH_MODE: str = "jit"` — class attribute override of PyAutoFit's `"vmap"` default. Inherited by `AnalysisImaging`, `AnalysisInterferometer`, `AnalysisEllipse`, `AnalysisQuantity`, and downstream PyAutoLens subclasses.

### Changed Signature
- None.

### Changed Behaviour
- For PyAutoGalaxy/PyAutoLens analyses, `compute_latent_samples` with `use_jax=True` now dispatches via per-sample `jax.jit` instead of `jax.jit(jax.vmap(...))`. JIT compile cache is reused across samples; speed is faster than per-sample NumPy but slower than the (vmap-incompatible) batched ideal. Required to unlock JAX-mode lensing latents at all.

### Migration
- None required. Existing callers of `einstein_radius_via_zero_contour_from` are unchanged. New `einstein_radius_jit_from` is an additive opt-in for JIT contexts.

</details>

## Companion PRs

- PyAutoFit: `https://github.com/rhayes777/PyAutoFit/pull/1288` — adds the `LATENT_BATCH_MODE` attribute machinery this override depends on.
- Workspace: `https://github.com/PyAutoLabs/euclid_strong_lens_modeling_pipeline/pull/15` — wires the Euclid `effective_einstein_radius` latent through `einstein_radius_jit_from`.

Closes PyAutoLabs/euclid_strong_lens_modeling_pipeline#14 alongside the companion PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)