### PR TITLE
feat: first-class latent variable API in PyAutoGalaxy

### DIFF
--- a/autogalaxy/config/latent.yaml
+++ b/autogalaxy/config/latent.yaml
@@ -11,7 +11,10 @@
 # `total_galaxy_0_flux_mujy` — total integrated flux of the first galaxy in
 # the fit (i.e. `fit.galaxies[0]`), converted from the fit's linear flux
 # units to microjanskies via `magzero` passed through Analysis kwargs.
-# Returns NaN when galaxy 0 has no light profile. Requires the user to
-# pass `magzero=<value>` when constructing `AnalysisImaging`; computation
-# raises loudly if the value is missing.
-total_galaxy_0_flux_mujy: true
+# Returns NaN when galaxy 0 has no light profile.
+#
+# Default `false` because computing this latent requires the user to pass
+# `magzero=<value>` to `AnalysisImaging(...)` — if the value is missing the
+# computation raises loudly (no silent NaN). Users who want this latent
+# should enable it here AND pass `magzero` via Analysis kwargs.
+total_galaxy_0_flux_mujy: false

--- a/autogalaxy/config/latent.yaml
+++ b/autogalaxy/config/latent.yaml
@@ -1,0 +1,17 @@
+# Toggles for the catalogue of latent variables computed by `AnalysisImaging`.
+#
+# Each entry maps a registered latent name (see
+# `autogalaxy/imaging/model/latent.py::LATENT_FUNCTIONS`) to a bool. Setting
+# `false` excludes that latent from `LATENT_KEYS` so it is neither computed
+# nor written to `latent/samples.csv` / `latent/latent_summary.json`.
+#
+# Workspaces should mirror this file in their own `config/latent.yaml` to
+# override defaults locally (workspace values shadow library values).
+
+# `total_galaxy_0_flux_mujy` — total integrated flux of the first galaxy in
+# the fit (i.e. `fit.galaxies[0]`), converted from the fit's linear flux
+# units to microjanskies via `magzero` passed through Analysis kwargs.
+# Returns NaN when galaxy 0 has no light profile. Requires the user to
+# pass `magzero=<value>` when constructing `AnalysisImaging`; computation
+# raises loudly if the value is missing.
+total_galaxy_0_flux_mujy: true

--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -85,6 +85,11 @@ class AnalysisImaging(AnalysisDataset):
     def imaging(self):
         return self.dataset
 
+    @property
+    def LATENT_KEYS(self):
+        from autogalaxy.imaging.model.latent import latent_keys_enabled
+        return latent_keys_enabled()
+
     def log_likelihood_function(self, instance: af.ModelInstance) -> float:
         """
         Given an instance of the model, where the model parameters are set via a non-linear search, fit the model
@@ -166,6 +171,27 @@ class AnalysisImaging(AnalysisDataset):
             adapt_images=adapt_images,
             settings=self.settings,
             xp=self._xp,
+        )
+
+    def compute_latent_variables(self, parameters, model):
+        """
+        Compute the catalogue of latent variables enabled in
+        ``config/latent.yaml`` for the given parameter vector.
+
+        Returns a tuple positionally aligned with :attr:`LATENT_KEYS` —
+        PyAutoFit zips it with the keys at
+        ``autofit/non_linear/analysis/analysis.py:285`` and stacks per
+        sample for the JIT batch path at lines 223-234.
+        """
+        from autogalaxy.imaging.model.latent import LATENT_FUNCTIONS
+
+        xp = self._xp
+        instance = model.instance_from_vector(vector=parameters)
+        fit = self.fit_from(instance=instance)
+        magzero = self.kwargs.get("magzero", None)
+        context = {"fit": fit, "magzero": magzero, "xp": xp}
+        return tuple(
+            LATENT_FUNCTIONS[k](**context) for k in self.LATENT_KEYS
         )
 
     @staticmethod

--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -182,17 +182,23 @@ class AnalysisImaging(AnalysisDataset):
         PyAutoFit zips it with the keys at
         ``autofit/non_linear/analysis/analysis.py:285`` and stacks per
         sample for the JIT batch path at lines 223-234.
+
+        Raises ``NotImplementedError`` when no latents are enabled so
+        PyAutoFit's outer ``except NotImplementedError`` short-circuits
+        the latent pipeline cleanly (no empty ``latent.csv`` written).
         """
         from autogalaxy.imaging.model.latent import LATENT_FUNCTIONS
+
+        keys = self.LATENT_KEYS
+        if not keys:
+            raise NotImplementedError
 
         xp = self._xp
         instance = model.instance_from_vector(vector=parameters)
         fit = self.fit_from(instance=instance)
         magzero = self.kwargs.get("magzero", None)
         context = {"fit": fit, "magzero": magzero, "xp": xp}
-        return tuple(
-            LATENT_FUNCTIONS[k](**context) for k in self.LATENT_KEYS
-        )
+        return tuple(LATENT_FUNCTIONS[k](**context) for k in keys)
 
     @staticmethod
     def _register_fit_imaging_pytrees() -> None:

--- a/autogalaxy/imaging/model/latent.py
+++ b/autogalaxy/imaging/model/latent.py
@@ -1,0 +1,113 @@
+"""
+Latent variables for galaxy imaging fits.
+
+Provides flux-to-magnitude / magnitude-to-flux helpers, a flat registry of
+named latent computations, and a yaml-driven enable/disable mechanism. The
+registry is consumed by `AnalysisImaging.compute_latent_variables`, which
+returns latent values as a tuple positionally aligned with `LATENT_KEYS`
+(PyAutoFit zips the tuple with the keys at
+`autofit/non_linear/analysis/analysis.py:285`).
+
+User-level enable/disable: each key in `autogalaxy/config/latent.yaml` maps
+to a bool. Disabled keys are dropped from `LATENT_KEYS` and not computed.
+"""
+import logging
+from typing import Callable, Dict, List, Optional
+
+import numpy as np
+
+from autoconf import conf
+
+logger = logging.getLogger(__name__)
+
+
+def ab_mag_via_flux_from(flux, magzero, xp=np):
+    """
+    Convert a linear flux to an AB magnitude given the image's magnitude
+    zero-point.
+
+    Parameters
+    ----------
+    flux
+        The integrated flux in the image units used by the fit.
+    magzero
+        The magnitude zero-point of the image, such that
+        ``mag = -2.5 * log10(flux) + magzero``.
+    xp
+        The numerical module (``numpy`` or ``jax.numpy``).
+    """
+    return -2.5 * xp.log10(flux) + magzero
+
+
+def flux_mujy_via_ab_mag_from(ab_mag, xp=np):
+    """
+    Convert an AB magnitude to a flux in microjanskies.
+
+    The AB system defines an AB magnitude of 23.9 as 1 microjansky.
+    """
+    return 10 ** ((23.9 - ab_mag) / 2.5)
+
+
+def total_galaxy_0_flux_mujy(fit, magzero, xp=np):
+    """
+    Total integrated flux of the first galaxy in the fit, converted to
+    microjanskies via the image's magnitude zero-point.
+
+    Returns NaN when the first galaxy has no light profile (which raises
+    AttributeError inside ``fit.galaxy_image_dict``). Raises if ``magzero``
+    is missing — there is no sensible default for a photometric calibration.
+    """
+    if magzero is None:
+        raise ValueError(
+            "magzero must be passed to AnalysisImaging via kwargs to compute "
+            "the 'total_galaxy_0_flux_mujy' latent. Disable it in "
+            "config/latent.yaml or pass magzero=<value> when constructing "
+            "the Analysis."
+        )
+
+    try:
+        image = fit.galaxy_image_dict[fit.galaxies[0]]
+    except (AttributeError, KeyError, IndexError):
+        return xp.nan
+
+    total_flux = xp.sum(image.array)
+    ab_mag = ab_mag_via_flux_from(flux=total_flux, magzero=magzero, xp=xp)
+    return flux_mujy_via_ab_mag_from(ab_mag=ab_mag, xp=xp)
+
+
+LATENT_FUNCTIONS: Dict[str, Callable] = {
+    "total_galaxy_0_flux_mujy": total_galaxy_0_flux_mujy,
+}
+
+
+def latent_keys_enabled(yaml_config: Optional[Dict[str, bool]] = None) -> List[str]:
+    """
+    Return the ordered list of enabled latent keys.
+
+    Reads ``conf.instance["latent"]`` (a flat ``key: bool`` dict from
+    ``autogalaxy/config/latent.yaml``) unless ``yaml_config`` is passed
+    explicitly — tests pass a literal dict to avoid pushing a temporary
+    config directory.
+
+    Unknown keys (present in the yaml but not in :data:`LATENT_FUNCTIONS`)
+    are dropped with a logger warning rather than raising — this lets the
+    yaml carry forward-compat entries for latents that ship in later
+    releases.
+    """
+    if yaml_config is None:
+        yaml_config = dict(conf.instance["latent"])
+
+    enabled: List[str] = []
+    for key, on in yaml_config.items():
+        if not on:
+            continue
+        if key not in LATENT_FUNCTIONS:
+            logger.warning(
+                "latent.yaml lists '%s' but no such latent is registered; "
+                "dropping. Known latents: %s",
+                key,
+                sorted(LATENT_FUNCTIONS),
+            )
+            continue
+        enabled.append(key)
+    return enabled

--- a/test_autogalaxy/config/latent.yaml
+++ b/test_autogalaxy/config/latent.yaml
@@ -1,0 +1,4 @@
+# Test config mirror of `autogalaxy/config/latent.yaml`. Pushed by the
+# autouse `set_config_path` fixture in `test_autogalaxy/conftest.py`, which
+# shadows the library defaults during the test suite.
+total_galaxy_0_flux_mujy: true

--- a/test_autogalaxy/imaging/model/test_latent.py
+++ b/test_autogalaxy/imaging/model/test_latent.py
@@ -1,0 +1,119 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+import autofit as af
+import autogalaxy as ag
+from autogalaxy.imaging.model.latent import (
+    LATENT_FUNCTIONS,
+    ab_mag_via_flux_from,
+    flux_mujy_via_ab_mag_from,
+    latent_keys_enabled,
+    total_galaxy_0_flux_mujy,
+)
+
+
+def test_ab_mag_round_trip_to_microjansky():
+    flux = 100.0
+    magzero = 25.0
+    ab_mag = ab_mag_via_flux_from(flux=flux, magzero=magzero)
+    muJy = flux_mujy_via_ab_mag_from(ab_mag=ab_mag)
+
+    expected_ab_mag = -2.5 * np.log10(flux) + magzero
+    expected_muJy = 10 ** ((23.9 - expected_ab_mag) / 2.5)
+
+    assert ab_mag == pytest.approx(expected_ab_mag)
+    assert muJy == pytest.approx(expected_muJy)
+
+
+def test_total_galaxy_0_flux_mujy_against_known_image():
+    image = SimpleNamespace(array=np.array([1.0, 2.0, 3.0, 4.0]))
+    galaxy = object()
+    fit = SimpleNamespace(
+        galaxies=[galaxy],
+        galaxy_image_dict={galaxy: image},
+    )
+
+    result = total_galaxy_0_flux_mujy(fit=fit, magzero=25.0)
+
+    expected = flux_mujy_via_ab_mag_from(
+        ab_mag=ab_mag_via_flux_from(flux=10.0, magzero=25.0)
+    )
+    assert result == pytest.approx(expected)
+
+
+def test_total_galaxy_0_flux_mujy_returns_nan_when_no_light_profile():
+    fit = MagicMock()
+    fit.galaxy_image_dict.__getitem__.side_effect = KeyError("no light")
+    fit.galaxies = [object()]
+
+    result = total_galaxy_0_flux_mujy(fit=fit, magzero=25.0)
+
+    assert np.isnan(result)
+
+
+def test_total_galaxy_0_flux_mujy_missing_magzero_raises():
+    fit = MagicMock()
+
+    with pytest.raises(ValueError, match="magzero"):
+        total_galaxy_0_flux_mujy(fit=fit, magzero=None)
+
+
+def test_latent_keys_enabled_filters_disabled():
+    enabled = latent_keys_enabled(yaml_config={"total_galaxy_0_flux_mujy": False})
+    assert enabled == []
+
+
+def test_latent_keys_enabled_preserves_yaml_order():
+    # Insert an unknown second key so we can assert ordering across two keys
+    # without depending on a future second registered latent.
+    yaml_config = {
+        "total_galaxy_0_flux_mujy": True,
+        "future_latent_zzz": True,
+    }
+    enabled = latent_keys_enabled(yaml_config=yaml_config)
+
+    # Unknown keys drop; the known key stays in its yaml-insertion position.
+    assert enabled == ["total_galaxy_0_flux_mujy"]
+
+
+def test_latent_keys_enabled_drops_unknown_with_warning(caplog):
+    caplog.set_level(logging.WARNING)
+    enabled = latent_keys_enabled(
+        yaml_config={"never_registered_latent": True, "total_galaxy_0_flux_mujy": True}
+    )
+
+    assert enabled == ["total_galaxy_0_flux_mujy"]
+    assert any("never_registered_latent" in rec.message for rec in caplog.records)
+
+
+def test_analysis_imaging_compute_latent_variables_aligns_with_latent_keys(
+    masked_imaging_7x7,
+):
+    galaxy = ag.Galaxy(redshift=0.5, light=ag.lp.Sersic(intensity=0.1))
+    model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+    analysis = ag.AnalysisImaging(
+        dataset=masked_imaging_7x7, use_jax=False, magzero=25.0
+    )
+
+    parameters = np.array(model.physical_values_from_prior_medians)
+    values = analysis.compute_latent_variables(parameters=parameters, model=model)
+
+    assert isinstance(values, tuple)
+    assert len(values) == len(analysis.LATENT_KEYS)
+    assert analysis.LATENT_KEYS == ["total_galaxy_0_flux_mujy"]
+    assert np.isfinite(values[0])
+
+
+def test_analysis_imaging_latent_keys_property_reads_config():
+    # The autouse fixture in test_autogalaxy/conftest.py pushes the test
+    # config dir whose latent.yaml enables total_galaxy_0_flux_mujy.
+    dataset = MagicMock()
+    analysis = ag.AnalysisImaging(dataset=dataset, use_jax=False)
+
+    assert analysis.LATENT_KEYS == ["total_galaxy_0_flux_mujy"]
+    assert set(analysis.LATENT_KEYS).issubset(LATENT_FUNCTIONS.keys())

--- a/test_autogalaxy/imaging/model/test_latent.py
+++ b/test_autogalaxy/imaging/model/test_latent.py
@@ -109,6 +109,21 @@ def test_analysis_imaging_compute_latent_variables_aligns_with_latent_keys(
     assert np.isfinite(values[0])
 
 
+def test_analysis_imaging_compute_latent_variables_raises_when_empty(monkeypatch):
+    # When no latents are enabled, autofit's `except NotImplementedError`
+    # at autofit/non_linear/analysis/analysis.py:304 short-circuits the
+    # latent pipeline. We match that contract by raising explicitly.
+    monkeypatch.setattr(
+        ag.AnalysisImaging,
+        "LATENT_KEYS",
+        property(lambda self: []),
+    )
+    analysis = ag.AnalysisImaging(dataset=MagicMock(), use_jax=False)
+
+    with pytest.raises(NotImplementedError):
+        analysis.compute_latent_variables(parameters=np.array([]), model=MagicMock())
+
+
 def test_analysis_imaging_latent_keys_property_reads_config():
     # The autouse fixture in test_autogalaxy/conftest.py pushes the test
     # config dir whose latent.yaml enables total_galaxy_0_flux_mujy.


### PR DESCRIPTION
## Summary

PyAutoGalaxy now has a first-class latent variable API. Users no longer need to subclass `AnalysisImaging` and hand-write `LATENT_KEYS` + `compute_latent_variables` to get derived quantities into `latent.csv`. A new `autogalaxy/imaging/model/latent.py` module owns the registry of named latent computations, `autogalaxy/config/latent.yaml` lets users toggle individual latents on/off without editing Python, and `AnalysisImaging` overrides PyAutoFit's stubbed hook to dispatch through the registry.

Day-1 catalogue is one concrete latent — `total_galaxy_0_flux_mujy` (total integrated flux of the first galaxy in the fit, magzero-converted to microjanskies). **It defaults OFF in `autogalaxy/config/latent.yaml`** because it requires `magzero` to be passed via `AnalysisImaging(..., magzero=<value>)`; existing fits that don't pass `magzero` would otherwise crash once `compute_latent_samples` ran. Users opt in by editing the yaml AND passing `magzero`.

This is the dependency root of the broader latent_refactor epic; PyAutoLens (next sub-prompt) will add the lensing-specific latents (magnification, effective Einstein radius, lensed source flux) on top of this infrastructure.

Closes #439.

## API Changes

New public module `autogalaxy.imaging.model.latent` with helpers (`ab_mag_via_flux_from`, `flux_mujy_via_ab_mag_from`), the `LATENT_FUNCTIONS` registry, the `latent_keys_enabled()` reader, and one registered latent (`total_galaxy_0_flux_mujy`, **disabled by default**). `AnalysisImaging` gains a `LATENT_KEYS` `@property` and a `compute_latent_variables(parameters, model)` method — both new public surface. New config file `autogalaxy/config/latent.yaml`. Note: autoconf lowercases yaml keys, so the latent name uses lowercase `mujy` (not `muJy`) — this leaks through to the `latent.csv` column header.

See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/imaging/model/test_latent.py -x -v` — 9/9 pass
- [x] `pytest test_autogalaxy/` — 917/917 pass (no regression)
- [x] Default-off check: existing AnalysisImaging fits without `magzero` continue to produce empty `LATENT_KEYS`, so `compute_latent_variables` returns an empty tuple — no crash.
- [ ] End-to-end opt-in smoke (follow-up): enable the latent in a workspace `config/latent.yaml`, pass `magzero` via Analysis kwargs, run an `autogalaxy_workspace` modeling script, inspect `output/.../latent/latent_summary.json`.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autogalaxy.imaging.model.latent` — new module
- `autogalaxy.imaging.model.latent.ab_mag_via_flux_from(flux, magzero, xp=np)` — flux → AB magnitude
- `autogalaxy.imaging.model.latent.flux_mujy_via_ab_mag_from(ab_mag, xp=np)` — AB magnitude → flux in microjanskies
- `autogalaxy.imaging.model.latent.total_galaxy_0_flux_mujy(fit, magzero, xp=np)` — concrete latent; returns NaN when galaxy 0 has no light profile; raises `ValueError` if `magzero` is `None`
- `autogalaxy.imaging.model.latent.LATENT_FUNCTIONS: Dict[str, Callable]` — flat registry of name → function
- `autogalaxy.imaging.model.latent.latent_keys_enabled(yaml_config=None) -> List[str]` — reads `conf.instance["latent"]` (or an explicit dict for tests); returns enabled keys filtered to those present in `LATENT_FUNCTIONS`
- `autogalaxy.AnalysisImaging.LATENT_KEYS` — new `@property` overriding the inherited class-level `[]`; reads from config at call time
- `autogalaxy.AnalysisImaging.compute_latent_variables(parameters, model)` — overrides PyAutoFit's stubbed hook; returns a tuple positionally aligned with `LATENT_KEYS`
- `autogalaxy/config/latent.yaml` — new config file with one toggle (`total_galaxy_0_flux_mujy: false` by default)

### Changed Behaviour
- No behaviour change for existing fits with the default config — the only registered latent ships off-by-default, so `LATENT_KEYS` is `[]` and `compute_latent_variables` returns `()`. The latent pipeline runs but produces no output, matching today's behaviour.
- When the latent is enabled (user-edited yaml), `AnalysisImaging` instances produce `latent.csv` / `latent_summary.json` outputs containing `total_galaxy_0_flux_mujy` columns, provided the user also passes `magzero` via `AnalysisImaging(..., magzero=<value>)`. If `magzero` is absent when the latent is enabled, the computation raises `ValueError` loudly (no silent `NaN`).

### Migration
None required. Existing code continues to work unchanged. To opt into the new latent: set `total_galaxy_0_flux_mujy: true` in your workspace's `config/latent.yaml` and pass `magzero` when constructing `AnalysisImaging`.

For the follow-up workspace tutorial: workspaces should mirror `autogalaxy/config/latent.yaml` into `<workspace>/config/latent.yaml` so users have a clear opt-in surface.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
