### PR TITLE
feat: SimulatorImaging.via_galaxies_from auto-default xp from parent use_jax

### DIFF
--- a/autogalaxy/imaging/simulator.py
+++ b/autogalaxy/imaging/simulator.py
@@ -20,7 +20,7 @@ from autogalaxy.galaxy.galaxies import Galaxies
 
 class SimulatorImaging(aa.SimulatorImaging):
     def via_galaxies_from(
-        self, galaxies: List[Galaxy], grid: aa.type.Grid2DLike
+        self, galaxies: List[Galaxy], grid: aa.type.Grid2DLike, xp=None
     ) -> aa.Imaging:
         """
         Simulate an `Imaging` dataset from an input list of `Galaxy` objects and a 2D grid of (y,x) coordinates.
@@ -48,6 +48,9 @@ class SimulatorImaging(aa.SimulatorImaging):
             to generate the image of the galaxies.
         """
 
+        if xp is None:
+            xp = self._xp
+
         galaxies = Galaxies(galaxies=galaxies)
 
         for galaxy in galaxies:
@@ -59,14 +62,14 @@ class SimulatorImaging(aa.SimulatorImaging):
             )
 
         image = galaxies.padded_image_2d_from(
-            grid=grid, psf_shape_2d=self.psf.kernel.shape_native
+            grid=grid, psf_shape_2d=self.psf.kernel.shape_native, xp=xp
         )
 
         over_sample_size = grid.over_sample_size.resized_from(
             new_shape=image.shape_native, mask_pad_value=1
         )
 
-        dataset = self.via_image_from(image=image, over_sample_size=over_sample_size)
+        dataset = self.via_image_from(image=image, over_sample_size=over_sample_size, xp=xp)
 
         return dataset.trimmed_after_convolution_from(
             kernel_shape=self.psf.kernel.shape_native


### PR DESCRIPTION
## Summary

Companion PR to the PyAutoArray PR adding `use_jax=True` to `aa.SimulatorImaging`. The autogalaxy `via_galaxies_from` override gains an `xp=None` parameter and defaults to `self._xp` from the parent — same pattern as the PyAutoLens `via_tracer_from` companion.

After all 3 PRs merge:
```python
simulator = ag.SimulatorImaging(exposure_time=300.0, psf=psf, use_jax=True)
dataset = simulator.via_galaxies_from(galaxies=galaxies, grid=grid)  # JAX-backed
```

## API Changes

- **Changed signature:** `ag.SimulatorImaging.via_galaxies_from(galaxies, grid, xp=None)` — `xp` now defaults to `None`. New behaviour: falls back to `self._xp` (inherited from `aa.SimulatorImaging`).

See full details below.

## Test Plan

- [x] PyAutoGalaxy 918/918 tests pass.
- [x] Eager cross-xp parity (via `autolens_workspace_test` parity script, bundled in the workspace_test follow-up).

<details>
<summary>Full API Changes</summary>

### Changed signature
- `ag.SimulatorImaging.via_galaxies_from(galaxies, grid, xp=None)` — gained `xp` parameter (previously not accepted). New behaviour: `xp=None` falls back to `self._xp`.

### Migration
- No breaking changes. Existing callers without `xp=` continue to work.

### Depends on
- Jammy2211/PyAutoArray PR adding `use_jax` to `aa.SimulatorImaging`. Merge PyAutoArray first.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)