### PR TITLE
feat: SimulatorInterferometer.via_galaxies_from auto-default xp from parent use_jax

### DIFF
--- a/autogalaxy/interferometer/simulator.py
+++ b/autogalaxy/interferometer/simulator.py
@@ -16,7 +16,7 @@ from autogalaxy.galaxy.galaxies import Galaxies
 
 
 class SimulatorInterferometer(aa.SimulatorInterferometer):
-    def via_galaxies_from(self, galaxies: List[Galaxy], grid: aa.type.Grid2DLike):
+    def via_galaxies_from(self, galaxies: List[Galaxy], grid: aa.type.Grid2DLike, xp=None):
         """
         Returns a realistic simulated image by applying effects to a plain simulated image.
 
@@ -37,8 +37,11 @@ class SimulatorInterferometer(aa.SimulatorInterferometer):
             A seed for random noise_maps generation
         """
 
+        if xp is None:
+            xp = self._xp
+
         galaxies = Galaxies(galaxies=galaxies)
 
-        image = galaxies.image_2d_from(grid=grid)
+        image = galaxies.image_2d_from(grid=grid, xp=xp)
 
-        return self.via_image_from(image=image)
+        return self.via_image_from(image=image, xp=xp)


### PR DESCRIPTION
## Summary

Companion PR to the PyAutoArray PR adding `use_jax=True` to `aa.SimulatorInterferometer`. The autogalaxy `via_galaxies_from` override gains an `xp=None` parameter and defaults to `self._xp` from the parent — same pattern as the PyAutoLens companion.

## API Changes

- **Changed signature:** `ag.SimulatorInterferometer.via_galaxies_from(galaxies, grid, xp=None)` — gained `xp` parameter; `xp=None` falls back to `self._xp`.

See full details below.

## Test Plan

- [x] PyAutoGalaxy 918/918 tests pass.

<details>
<summary>Full API Changes</summary>

### Changed signature
- `ag.SimulatorInterferometer.via_galaxies_from(galaxies, grid, xp=None)` — gained `xp` parameter (previously not accepted).

### Migration
- No breaking changes.

### Depends on
- Jammy2211/PyAutoArray PR. Merge PyAutoArray first.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)