### PR TITLE
refactor: port CSE module to support JAX via xp parameter

### DIFF
--- a/autogalaxy/profiles/mass/abstract/cse.py
+++ b/autogalaxy/profiles/mass/abstract/cse.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Tuple
 class MassProfileCSE(ABC):
     @staticmethod
     def convergence_cse_1d_from(
-        grid_radii: np.ndarray, core_radius: float
+        grid_radii: np.ndarray, core_radius: float, xp=np
     ) -> np.ndarray:
         """
         One dimensional function which is solved to decompose a convergence profile in cored steep ellipsoids, given by
@@ -30,6 +30,7 @@ class MassProfileCSE(ABC):
         term4: float,
         axis_ratio_squared: float,
         core_radius: float,
+        xp=np,
     ) -> np.ndarray:
         """
         Returns the deflection angles of a 1d cored steep ellisoid (CSE) profile, given by equation (19) and (20) of
@@ -40,12 +41,12 @@ class MassProfileCSE(ABC):
         Parameters
         ----------
         """
-        phi = np.sqrt(axis_ratio_squared * core_radius**2.0 + term1)
+        phi = xp.sqrt(axis_ratio_squared * core_radius**2.0 + term1)
         Psi = (phi + core_radius) ** 2.0 + term2
         bottom = core_radius * phi * Psi
         defl_x = (term3 * (phi + axis_ratio_squared * core_radius)) / bottom
         defl_y = (term4 * (phi + core_radius)) / bottom
-        return np.vstack((defl_y, defl_x))
+        return xp.vstack((defl_y, defl_x))
 
     @abstractmethod
     def decompose_convergence_via_cse(self, grid_radii: np.ndarray):
@@ -121,7 +122,7 @@ class MassProfileCSE(ABC):
         pass
 
     def _convergence_2d_via_cse_from(
-        self, grid_radii: np.ndarray, **kwargs
+        self, grid_radii: np.ndarray, xp=np, **kwargs
     ) -> np.ndarray:
         """
         Calculate the projected 2D convergence from a grid of radial coordinates, by computing and summing the
@@ -143,12 +144,12 @@ class MassProfileCSE(ABC):
         return sum(
             amplitude
             * self.convergence_cse_1d_from(
-                grid_radii=grid_radii, core_radius=core_radius
+                grid_radii=grid_radii, core_radius=core_radius, xp=xp
             )
             for amplitude, core_radius in zip(amplitude_list, core_radius_list)
         )
 
-    def _deflections_2d_via_cse_from(self, grid: np.ndarray, **kwargs) -> np.ndarray:
+    def _deflections_2d_via_cse_from(self, grid: np.ndarray, xp=np, **kwargs) -> np.ndarray:
         """
         Calculate the projected 2D deflection angles from a grid of radial coordinates, by computing and summing the
         deflections of each individual cse used to decompose the mass profile.
@@ -188,6 +189,7 @@ class MassProfileCSE(ABC):
                 term2=term2,
                 term3=term3,
                 term4=term4,
+                xp=xp,
             )
             for amplitude, core_radius in zip(amplitude_list, core_radius_list)
         )

--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -108,7 +108,7 @@ class NFW(gNFW, MassProfileCSE):
     @aa.decorators.to_vector_yx
     @aa.decorators.transform(rotate_back=True)
     def deflections_2d_via_cse_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return self._deflections_2d_via_cse_from(grid=grid, **kwargs)
+        return self._deflections_2d_via_cse_from(grid=grid, xp=xp, **kwargs)
 
     @aa.over_sample
     @aa.decorators.to_array
@@ -130,7 +130,7 @@ class NFW(gNFW, MassProfileCSE):
 
         elliptical_radii = self.elliptical_radii_grid_from(grid=grid, xp=xp, **kwargs)
 
-        return self._convergence_2d_via_cse_from(grid_radii=elliptical_radii)
+        return self._convergence_2d_via_cse_from(grid_radii=elliptical_radii, xp=xp)
 
     def convergence_func(self, grid_radius: float, xp=np) -> float:
         grid_radius = (1.0 / self.scale_radius) * grid_radius.array + 0j


### PR DESCRIPTION
## Summary

Port the CSE (Cored Steep Ellipsoid) module to support JAX by threading `xp=np` through all forward-path methods, mirroring the already JAX-ready MGE module. This unblocks JAX JIT compilation for any profile that uses CSE decomposition (primarily NFW). Phase 2 of the mass profiles refactoring epic (#445).

## API Changes

Added `xp=np` keyword argument to four `MassProfileCSE` methods: `convergence_cse_1d_from`, `deflections_via_cse_from`, `_convergence_2d_via_cse_from`, `_deflections_2d_via_cse_from`. Existing callers passing no `xp` argument are unaffected (default is `np`). The decomposition solver (`_decompose_convergence_via_cse_from`) stays NumPy-only — it runs before JIT tracing. See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/profiles/mass/` — 406 passed, 0 failed
- [ ] `profiles_jit.py` JAX three-step test for CSE-based profiles (follow-up on autolens_workspace_test)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Signature
- `MassProfileCSE.convergence_cse_1d_from(grid_radii, core_radius)` → `convergence_cse_1d_from(grid_radii, core_radius, xp=np)`
- `MassProfileCSE.deflections_via_cse_from(term1, term2, term3, term4, axis_ratio_squared, core_radius)` → adds `xp=np`
- `MassProfileCSE._convergence_2d_via_cse_from(grid_radii, **kwargs)` → adds `xp=np`
- `MassProfileCSE._deflections_2d_via_cse_from(grid, **kwargs)` → adds `xp=np`

### Changed Behaviour
- `deflections_via_cse_from` now uses `xp.sqrt` and `xp.vstack` instead of hardcoded `np.sqrt` / `np.vstack`
- `NFW.deflections_2d_via_cse_from` and `NFW.convergence_2d_via_cse_from` now thread `xp=xp` to CSE base methods

### Migration
No migration needed — all new `xp` parameters default to `np`, preserving existing behaviour.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)