### PR TITLE
feat: MGE/CSE fallback for zero-returning mass profile potentials

### DIFF
--- a/autogalaxy/profiles/mass/abstract/mge.py
+++ b/autogalaxy/profiles/mass/abstract/mge.py
@@ -390,6 +390,134 @@ class MGEDecomposer:
             intensity, xp.exp(-0.5 * xp.square(xp.divide(grid_radii.array, sigma)))
         )
 
+    @staticmethod
+    def E1(x, xp=np):
+        """Exponential integral of the first order via Abramowitz & Stegun (1970).
+
+        Polynomial approximation for x <= 1, rational approximation for x > 1.
+        Uses xp.where for branchless evaluation (JAX-compatible).
+
+        Reference: Abramowitz & Stegun, Handbook of Mathematical Functions, 5.1.53 / 5.1.56.
+        Same approximation used in Jax-Lensing-Profiles (Herculens).
+        """
+        A0 = -0.57721566
+        A1 = 0.99999193
+        A2 = -0.24991055
+        A3 = 0.05519968
+        A4 = -0.00976004
+        A5 = 0.00107857
+        B1 = 8.5733287401
+        B2 = 18.059016973
+        B3 = 8.6347608925
+        B4 = 0.2677737343
+        C1 = 9.5733223454
+        C2 = 25.6329561486
+        C3 = 21.0996530827
+        C4 = 3.9584969228
+
+        x_safe = xp.where(x > 0, x, 1e-20)
+        x2 = x_safe ** 2
+        x3 = x_safe ** 3
+        x4 = x_safe ** 4
+        x5 = x_safe ** 5
+
+        small = (
+            -xp.log(x_safe) + A0 + A1 * x_safe + A2 * x2
+            + A3 * x3 + A4 * x4 + A5 * x5
+        )
+        num = xp.exp(-x_safe) * (x4 + B1 * x3 + B2 * x2 + B3 * x_safe + B4)
+        denom = x5 + C1 * x4 + C2 * x3 + C3 * x2 + C4 * x_safe
+        large = num / denom
+
+        return xp.where(x_safe <= 1.0, small, large)
+
+    def potential_func_gaussian(self, grid_radii, sigma, intensity, xp=np):
+        EULER_GAMMA = 0.5772156649015329
+        value = 0.5 * xp.square(xp.divide(grid_radii.array, sigma))
+        value_safe = xp.where(value > 0, value, 1e-20)
+        return xp.multiply(
+            intensity,
+            xp.multiply(
+                sigma ** 2,
+                EULER_GAMMA + xp.log(value_safe) + self.E1(value_safe, xp),
+            ),
+        )
+
+    @aa.over_sample
+    @aa.decorators.to_array
+    @aa.decorators.transform
+    def potential_2d_via_mge_from(
+        self,
+        grid: aa.type.Grid2DLike,
+        xp=np,
+        *,
+        sigma_log_list,
+        three_D: bool,
+        ellipticity_convention: str,
+        func_terms: int = 28,
+        **kwargs,
+    ):
+        """Calculate the projected lensing potential at a given set of arc-second
+        gridded coordinates, via MGE decomposition of the convergence profile.
+
+        The potential for each Gaussian component is computed analytically using
+        the E1 (exponential integral) formula from Shajib (2019).
+        """
+        eccentric_radii = self.mass_profile.eccentric_radii_grid_from(
+            grid=grid, xp=xp, **kwargs
+        )
+
+        sigmas_factor = self.sigmas_factor_from(
+            input_convention=ellipticity_convention,
+            target_convention="circularised",
+            xp=xp,
+        )
+
+        return self._potential_2d_via_mge_from(
+            grid_radii=eccentric_radii,
+            xp=xp,
+            sigma_log_list=sigma_log_list,
+            three_D=three_D,
+            sigmas_factor=sigmas_factor,
+            func_terms=func_terms,
+        )
+
+    def _potential_2d_via_mge_from(
+        self,
+        grid_radii,
+        xp=np,
+        *,
+        sigma_log_list,
+        three_D: bool,
+        sigmas_factor: float = 1.0,
+        func_terms: int = 28,
+        **kwargs,
+    ):
+        sigma_log_array = xp.asarray(sigma_log_list, dtype=xp.float64)
+
+        amps, sigmas = self.decompose_convergence_via_mge(
+            sigma_log_list=sigma_log_array,
+            func_terms=func_terms,
+            three_D=three_D,
+            xp=xp,
+        )
+
+        sigmas = sigmas_factor * xp.asarray(sigmas)[:, None]
+        amps = xp.asarray(amps)[:, None]
+
+        grid_radii = grid_radii[None, ...]
+
+        potential = xp.sum(
+            self.potential_func_gaussian(
+                grid_radii=aa.ArrayIrregular(grid_radii),
+                sigma=sigmas,
+                intensity=amps,
+                xp=xp,
+            ),
+            axis=0,
+        )
+        return potential
+
     def sigmas_factor_from(self, input_convention: str, target_convention: str, xp=np):
         """
         Returns the multiplicative factor required to convert a scale parameter (e.g. sigma)

--- a/autogalaxy/profiles/mass/dark/cnfw.py
+++ b/autogalaxy/profiles/mass/dark/cnfw.py
@@ -75,21 +75,31 @@ class cNFW(AbstractgNFW):
             * (r.array + self.scale_radius) ** (-2.0)
         )
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        """
-        Convergence (dimensionless surface mass density) for the cored NFW profile.
-        This is not yet implemented for `cNFW`.
-        """
-        return xp.zeros(shape=grid.shape[0])
+        radii_min = self.scale_radius / 1000.0
+        radii_max = self.scale_radius * 200.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 20))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.convergence_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=True,
+        )
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        """
-        Lensing potential for the cored NFW profile.
-        This is not yet implemented for `cNFW`.
-        """
-        return xp.zeros(shape=grid.shape[0])
+        radii_min = self.scale_radius / 1000.0
+        radii_max = self.scale_radius * 200.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 20))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=True,
+        )
 
 
 class cNFWSph(cNFW):
@@ -235,18 +245,28 @@ class cNFWSph(cNFW):
 
         return 2 * dev_F
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        """
-        Convergence (dimensionless surface mass density) for the cored NFW profile.
-        This is not yet implemented for `cNFWSph`.
-        """
-        return xp.zeros(shape=grid.shape[0])
+        radii_min = self.scale_radius / 1000.0
+        radii_max = self.scale_radius * 200.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 20))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.convergence_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=True,
+        )
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        """
-        Lensing potential for the cored NFW profile.
-        This is not yet implemented for `cNFWSph`.
-        """
-        return xp.zeros(shape=grid.shape[0])
+        radii_min = self.scale_radius / 1000.0
+        radii_max = self.scale_radius * 200.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 20))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=True,
+        )

--- a/autogalaxy/profiles/mass/dark/nfw_truncated.py
+++ b/autogalaxy/profiles/mass/dark/nfw_truncated.py
@@ -62,9 +62,20 @@ class NFWTruncatedSph(AbstractgNFW):
             2.0 * self.kappa_s * self.coord_func_l(grid_radius=grid_radius.array, xp=xp)
         )
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return xp.zeros(shape=grid.shape[0])
+        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
+
+        radii_min = self.scale_radius / 1000.0
+        radii_max = self.truncation_radius * 5.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 30))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=True,
+        )
 
     def coord_func_k(self, grid_radius, xp=np):
         return xp.log(

--- a/autogalaxy/profiles/mass/point/point.py
+++ b/autogalaxy/profiles/mass/point/point.py
@@ -35,8 +35,10 @@ class PointMass(MassProfile):
         return convergence
 
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return np.zeros(shape=grid.shape[0])
+        r = xp.sqrt(grid.array[:, 0] ** 2 + grid.array[:, 1] ** 2 + 1e-20)
+        return self.einstein_radius ** 2 * xp.log(r)
 
     @aa.decorators.to_vector_yx
     @aa.decorators.transform

--- a/autogalaxy/profiles/mass/sheets/mass_sheet.py
+++ b/autogalaxy/profiles/mass/sheets/mass_sheet.py
@@ -30,7 +30,7 @@ class MassSheet(MassProfile):
 
     @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return xp.zeros(shape=grid.shape[0])
+        return 0.5 * self.kappa * (grid.array[:, 0] ** 2 + grid.array[:, 1] ** 2)
 
     @aa.decorators.to_vector_yx
     @aa.decorators.transform

--- a/autogalaxy/profiles/mass/stellar/chameleon.py
+++ b/autogalaxy/profiles/mass/stellar/chameleon.py
@@ -149,9 +149,20 @@ class Chameleon(MassProfile, StellarProfile):
             grid_radius, xp=xp
         )
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return xp.zeros(shape=grid.shape[0])
+        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
+
+        radii_min = self.core_radius_0 / 10.0
+        radii_max = self.core_radius_1 * 200.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 30))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="circularised", three_D=False,
+        )
 
     def image_2d_via_radii_from(self, grid_radii: np.ndarray, xp=np):
         """Calculate the intensity of the Chamelon light profile on a grid of radial coordinates.

--- a/autogalaxy/profiles/mass/stellar/gaussian.py
+++ b/autogalaxy/profiles/mass/stellar/gaussian.py
@@ -96,9 +96,20 @@ class Gaussian(MassProfile, StellarProfile):
             grid_radius, xp=xp
         )
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return xp.zeros(shape=grid.shape[0])
+        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
+
+        radii_min = self.sigma / 100.0
+        radii_max = self.sigma * 20.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 30))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="circularised", three_D=False,
+        )
 
     def image_2d_via_radii_from(self, grid_radii: np.ndarray, xp=np):
         """Calculate the intensity of the Gaussian light profile on a grid of radial coordinates.

--- a/autogalaxy/profiles/mass/stellar/sersic.py
+++ b/autogalaxy/profiles/mass/stellar/sersic.py
@@ -183,9 +183,20 @@ class AbstractSersic(MassProfile, MassProfileCSE, StellarProfile):
             grid_radius, xp=xp
         )
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return np.zeros(shape=grid.shape[0])
+        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
+
+        radii_min = self.effective_radius / 100.0
+        radii_max = self.effective_radius * 20.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 30))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="circularised", three_D=False,
+        )
 
     def image_2d_via_radii_from(self, radius: np.ndarray, xp=np):
         """

--- a/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_mass.py
+++ b/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_mass.py
@@ -529,9 +529,20 @@ class dPIEMass(MassProfile):
 
         return aa.Array2D(values=1.0 / det_A, mask=grid.mask)
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return xp.zeros(shape=grid.shape[0])
+        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
+
+        radii_min = max(self.ra, 0.001) / 10.0
+        radii_max = self.rs * 20.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 30))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=False,
+        )
 
 
 class dPIEMassSph(dPIEMass):

--- a/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_potential.py
+++ b/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_potential.py
@@ -151,9 +151,20 @@ class dPIEPotential(MassProfile):
         # zero over all space
         return kappa_circ * (1 - asymm_term) + (alpha_circ / grid_radii) * asymm_term
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return xp.zeros(shape=grid.shape[0])
+        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
+
+        radii_min = max(self.ra, 0.001) / 10.0
+        radii_max = self.rs * 20.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 30))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=False,
+        )
 
 
 class dPIEPotentialSph(dPIEPotential):
@@ -249,6 +260,17 @@ class dPIEPotentialSph(dPIEPotential):
 
         return self._convergence(xp.sqrt(radsq), xp)
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return xp.zeros(shape=grid.shape[0])
+        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
+
+        radii_min = max(self.ra, 0.001) / 10.0
+        radii_max = self.rs * 20.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 30))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=False,
+        )

--- a/autogalaxy/profiles/mass/total/power_law_broken.py
+++ b/autogalaxy/profiles/mass/total/power_law_broken.py
@@ -69,9 +69,20 @@ class PowerLawBroken(MassProfile):
             radius > self.break_radius
         )
 
+    @aa.over_sample
     @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        return xp.zeros(shape=grid.shape[0])
+        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
+
+        radii_min = self.break_radius / 100.0
+        radii_max = self.einstein_radius * 20.0
+        sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 30))
+        mge_decomp = MGEDecomposer(mass_profile=self)
+        return mge_decomp.potential_2d_via_mge_from(
+            grid=grid, xp=xp, sigma_log_list=sigmas,
+            ellipticity_convention="major", three_D=False,
+        )
 
     @aa.decorators.to_vector_yx
     @aa.decorators.transform(rotate_back=True)

--- a/test_autogalaxy/profiles/mass/sheets/test_mass_sheet.py
+++ b/test_autogalaxy/profiles/mass/sheets/test_mass_sheet.py
@@ -97,6 +97,6 @@ def test__potential_2d_from():
         grid=ag.Grid2DIrregular([[1.0, 0.0], [3.0, 3.0], [5.0, -9.0]])
     )
 
-    assert potential[0] == pytest.approx(0.0, 1e-3)
-    assert potential[1] == pytest.approx(0.0, 1e-3)
-    assert potential[2] == pytest.approx(0.0, 1e-3)
+    assert potential[0] == pytest.approx(0.5, 1e-3)
+    assert potential[1] == pytest.approx(9.0, 1e-3)
+    assert potential[2] == pytest.approx(53.0, 1e-3)


### PR DESCRIPTION
## Summary

Replace zero-returning `potential_2d_from` and `convergence_2d_from` methods across 10 mass profiles with proper implementations. Adds a new `potential_2d_via_mge_from` method to `MGEDecomposer` using the E1 (exponential integral) formula from Shajib (2019), cross-validated against Jax-Lensing-Profiles (Herculens). Phase 3 of the mass profiles refactoring epic (#445).

Three tiers of implementation:
- **Analytic**: PointMass (ψ = R_E² ln r) and MassSheet (ψ = ½κr²)
- **MGE convergence**: cNFW/cNFWSph now compute convergence via MGE (same pattern as their existing MGE-based deflections)
- **MGE potential**: All remaining profiles (Sersic, Gaussian, Chameleon, PowerLawBroken, dPIE families, NFWTruncated, cNFW) compute potential via the new `potential_2d_via_mge_from`

Self-consistency validated: laplacian(ψ_MGE) = 2κ_MGE to 0.3% median error. The ~5-9% error vs profiles with known analytic potentials is inherent to the MGE decomposition (convergence itself has similar error), not the potential formula.

## API Changes

Added `MGEDecomposer.potential_2d_via_mge_from()` — new public method computing lensing potential from MGE-decomposed convergence using the E1 exponential integral. Added helper methods `E1()` (Abramowitz & Stegun approximation, JAX-compatible) and `potential_func_gaussian()`. All existing zero-returning methods now return physically meaningful values instead of zeros. See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/profiles/mass/` — 406 passed, 0 failed
- [x] MGE potential self-consistency: laplacian(ψ) = 2κ to 0.3% median
- [x] MGE potential vs Isothermal/PowerLaw analytic: ~5% median (decomposition-limited)
- [x] Updated `test_mass_sheet.py` to match new correct potential values
- [ ] Phase 1 self-consistency tests (autolens_workspace_test scripts/mass/) — follow-up

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `MGEDecomposer.E1(x, xp)` — static method, exponential integral of first order (Abramowitz & Stegun 1970)
- `MGEDecomposer.potential_func_gaussian(grid_radii, sigma, intensity, xp)` — potential of a single Gaussian convergence component
- `MGEDecomposer.potential_2d_via_mge_from(grid, *, sigma_log_list, three_D, ellipticity_convention, ...)` — lensing potential via MGE decomposition
- `MGEDecomposer._potential_2d_via_mge_from(grid_radii, *, sigma_log_list, ...)` — internal implementation

### Changed Behaviour
- `PointMass.potential_2d_from` — was zeros, now returns ψ = R_E² ln(r)
- `MassSheet.potential_2d_from` — was zeros, now returns ψ = ½κr²
- `cNFW.convergence_2d_from` / `cNFWSph.convergence_2d_from` — was zeros, now MGE-computed
- `cNFW.potential_2d_from` / `cNFWSph.potential_2d_from` — was zeros, now MGE-computed
- `NFWTruncatedSph.potential_2d_from` — was zeros, now MGE-computed
- `AbstractSersic.potential_2d_from` (Sersic, SersicSph) — was zeros, now MGE-computed
- `Gaussian.potential_2d_from` — was zeros, now MGE-computed
- `Chameleon.potential_2d_from` — was zeros, now MGE-computed
- `PowerLawBroken.potential_2d_from` — was zeros, now MGE-computed
- `dPIEMass.potential_2d_from` — was zeros, now MGE-computed
- `dPIEPotential.potential_2d_from` / `dPIEPotentialSph.potential_2d_from` — was zeros, now MGE-computed

### Migration
No migration needed — methods that returned zeros now return physically correct values. Any code that relied on these methods returning zeros was already broken (using a placeholder).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)