### PR TITLE
fix: cNFWSph deflection boundary bug and MCR validation (#451)

### DIFF
--- a/autogalaxy/profiles/mass/dark/cnfw.py
+++ b/autogalaxy/profiles/mass/dark/cnfw.py
@@ -214,10 +214,7 @@ class cNFWSph(cNFW):
 
         F = theta * 0.0
 
-        # theta < radius
-        mask1 = (theta > 0) & (theta < radius)
-
-        # theta > radius
+        mask1 = (theta > 0) & (theta <= radius)
         mask2 = theta > radius
 
         F = xp.where(

--- a/autogalaxy/profiles/mass/dark/mcr_util.py
+++ b/autogalaxy/profiles/mass/dark/mcr_util.py
@@ -209,6 +209,20 @@ def kappa_s_scale_radius_and_core_radius_for_ludlow(
         (1 + concentration) * (1 - f_c)
     )  # mass concentration relation (Penarrubia+2012)
 
+    if xp is np and mcr_penarrubia <= 0:
+        import warnings
+
+        warnings.warn(
+            f"cNFW Penarrubia MCR integral factor is non-positive "
+            f"({mcr_penarrubia:.4e}) for f_c={f_c:.4f}, "
+            f"concentration={concentration:.2f}. This produces an unphysical "
+            f"negative kappa_s. The cored NFW parameterisation is not valid "
+            f"for core fractions this large (f_c > ~0.18 for typical "
+            f"concentrations). Clamping to a small positive value.",
+            stacklevel=3,
+        )
+        mcr_penarrubia = 1e-10
+
     scale_radius_kpc = radius_at_200 / concentration  # scale radius in kpc
     rho_0 = mass_at_200 / (4 * xp.pi * scale_radius_kpc**3 * mcr_penarrubia)
     kappa_s = rho_0 * scale_radius_kpc / critical_surface_density  # kappa_s


### PR DESCRIPTION
## Summary

Fixes two bugs in the cored NFW profile reported in #451:

1. **F_func boundary condition**: `cNFWSph.F_func` used strict `<`/`>` masks, so `theta == scale_radius` fell through both branches and returned zero — producing wildly wrong deflections at that exact radius. Changed to `<=`.

2. **Peñarrubia MCR integral crosses zero for large f_c**: The MCR integral factor becomes non-positive at f_c > ~0.18 (typical concentrations), causing `kappa_s` to diverge and go negative. Added a runtime warning and clamp to prevent NaN/Inf propagation.

The third problem from #451 (convergence returning zeros) was already fixed in #449.

## API Changes

None — internal bug fix. The warning for invalid f_c is new user-visible behaviour.

## Test Plan

- [x] \`pytest test_autogalaxy/profiles/mass/\` — 406 passed, 0 failed
- [x] F_func boundary: cNFWSph at theta = r_s now matches MGE to 0.01% (was 320% error)
- [x] MCR validation: f_c=0.3 and f_c=0.5 trigger warning and clamp (were silently negative)
- [x] f_c to 0 convergence to NFW still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)