### PR TITLE
fix: add xp=np to convergence_func across all mass profiles

### DIFF
--- a/autogalaxy/profiles/mass/abstract/abstract.py
+++ b/autogalaxy/profiles/mass/abstract/abstract.py
@@ -155,7 +155,7 @@ class MassProfile(EllProfile):
         """
         raise NotImplementedError
 
-    def convergence_func(self, grid_radius: float) -> float:
+    def convergence_func(self, grid_radius: float, xp=np) -> float:
         """
         Returns the convergence of the mass profile as a function of the radial coordinate.
 

--- a/autogalaxy/profiles/mass/sheets/external_potential.py
+++ b/autogalaxy/profiles/mass/sheets/external_potential.py
@@ -164,7 +164,7 @@ class ExternalPotential(MassProfile):
     def delta_angle(self, xp=np):
         return self._angle_from(self.delta_1, self.delta_2, harmonic=3, xp=xp)
 
-    def convergence_func(self, grid_radius: float) -> float:
+    def convergence_func(self, grid_radius: float, xp=np) -> float:
         return 0.0
 
     def average_convergence_of_1_radius(self):

--- a/autogalaxy/profiles/mass/sheets/external_shear.py
+++ b/autogalaxy/profiles/mass/sheets/external_shear.py
@@ -98,7 +98,7 @@ class ExternalShear(MassProfile):
             gamma_1=self.gamma_1, gamma_2=self.gamma_2, xp=xp
         )
 
-    def convergence_func(self, grid_radius: float) -> float:
+    def convergence_func(self, grid_radius: float, xp=np) -> float:
         return 0.0
 
     def average_convergence_of_1_radius(self):

--- a/autogalaxy/profiles/mass/sheets/mass_sheet.py
+++ b/autogalaxy/profiles/mass/sheets/mass_sheet.py
@@ -47,7 +47,7 @@ class MassSheet(MassProfile):
         super().__init__(centre=centre, ell_comps=(0.0, 0.0))
         self.kappa = kappa
 
-    def convergence_func(self, grid_radius: float) -> float:
+    def convergence_func(self, grid_radius: float, xp=np) -> float:
         return 0.0
 
     @aa.decorators.to_array

--- a/autogalaxy/profiles/mass/stellar/sersic_gradient.py
+++ b/autogalaxy/profiles/mass/stellar/sersic_gradient.py
@@ -65,7 +65,7 @@ class SersicGradient(AbstractSersic):
             self.eccentric_radii_grid_from(grid=grid, xp=xp, **kwargs)
         )
 
-    def convergence_func(self, grid_radius: float) -> float:
+    def convergence_func(self, grid_radius: float, xp=np) -> float:
         return (
             self.mass_to_light_ratio
             * (


### PR DESCRIPTION
## Summary

Add missing `xp=np` parameter to `convergence_func` in 5 locations where it was absent: `MassProfile` base class, `ExternalShear`, `ExternalPotential`, `MassSheet`, and `SersicGradient`. This allows `MGEDecomposer.decompose_convergence_via_mge` to call `convergence_func(xp=xp)` without TypeError, unblocking MGE-based potential computation for PowerLawBroken, dPIE, and SersicGradient profiles. Fixes #456.

## API Changes

Added `xp=np` keyword to 5 `convergence_func` signatures. Default is `np` so existing callers are unaffected.

## Test Plan

- [x] `pytest test_autogalaxy/profiles/mass/` — 406 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)