### PR TITLE
fix: use xp.sqrt in NFWSph.potential_func_sph

### DIFF
--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -419,5 +419,5 @@ class NFWSph(NFW):
     @staticmethod
     def potential_func_sph(eta, xp=np):
         return ((xp.log(eta.array / 2.0)) ** 2) - (
-            xp.arctanh(np.sqrt(1 - eta.array**2))
+            xp.arctanh(xp.sqrt(1 - eta.array**2))
         ) ** 2


### PR DESCRIPTION
One-line fix: hardcoded np.sqrt broke JAX path for NFWSph potential. Changed to xp.sqrt.