### PR TITLE
docs: fix dead HowToGalaxy Colab links + purge stale allowlist entries

### DIFF
--- a/.url_check_allowlist.txt
+++ b/.url_check_allowlist.txt
@@ -12,11 +12,6 @@ https://academic.oup.com/mnras/article/488/1/1387/5526256  # autogalaxy/profiles
 # Code of Conduct boilerplate
 http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy  # CODE_OF_CONDUCT.md:305
 
-# Colab refs to notebooks no longer in HowTo/workspace
-https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.5.14.2/notebooks/chapter_4_pixelizations/tutorial_6_model_fit.ipynb  # docs/howtogalaxy/chapter_4_pixelizations.md:19
-https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.5.14.2/notebooks/chapter_optional/tutorial_mass_profiles.ipynb  # docs/howtogalaxy/chapter_optional.md:7
-https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.5.14.2/notebooks/chapter_optional/tutorial_sub_grids.ipynb  # docs/howtogalaxy/chapter_optional.md:10
-
 # External dead / paywalled / departmental pages
 http://www.astro.uvic.ca/~simard/GIM2D/  # paper/paper.md:188
 https://bitbucket.org/bdiemer/colossus/src/main/  # files/citations.md:12

--- a/docs/howtogalaxy/chapter_4_pixelizations.md
+++ b/docs/howtogalaxy/chapter_4_pixelizations.md
@@ -16,5 +16,5 @@ The chapter contains the following tutorials:
 [Tutorial 4: Bayesian Regularization](https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.7.6.649/notebooks/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb)
 \- Smoothing the source within a Bayesian framework.
 
-[Tutorial 6: Model Fit](https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.7.6.649/notebooks/chapter_4_pixelizations/tutorial_6_model_fit.ipynb)
+[Tutorial 5: Model Fit](https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.7.6.649/notebooks/chapter_4_pixelizations/tutorial_5_model_fit.ipynb)
 \- An example modeling pipeline which uses an inversion.

--- a/docs/howtogalaxy/chapter_optional.md
+++ b/docs/howtogalaxy/chapter_optional.md
@@ -4,11 +4,5 @@ This chapter contains optional tutorials expanding on different aspects of how *
 
 The chapter contains the following tutorials:
 
-[Tutorial: Mass Profiles](https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.7.6.649/notebooks/chapter_optional/tutorial_mass_profiles.ipynb)
-\- A description of mass profiles implemented in PyAutoGalaxy, which are currently only used by its child project PyAutoLens.
-
-[Tutorial: Sub-grids](https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.7.6.649/notebooks/chapter_optional/tutorial_sub_grids.ipynb)
-\- Use sub-grids to perform more accurate and precise calculations.
-
 [Tutorial: Searches](https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.7.6.649/notebooks/chapter_optional/tutorial_searches.ipynb)
 \- Alternative non-linear searches to sample parameter space.


### PR DESCRIPTION
## Summary

Final leg of the Colab maturity work (tracker PyAutoLabs/PyAutoBuild#124). Fixes the three dead HowToGalaxy Colab links in `docs/howtogalaxy/` — the model-fit entry becomes **Tutorial 5: Model Fit** matching the actual `tutorial_5_model_fit` notebook (the chapter has five tutorials, not six), and the entries for the deleted `chapter_optional` mass-profiles / sub-grids tutorials are removed (the chapter now contains only `tutorial_searches`) — and purges the three grandfathered Colab entries from `.url_check_allowlist.txt`.

Every Colab URL in the repo is machine-verified (canonical owner, current tag, target notebook exists in HowToGalaxy) and Heart's hardened offline guard exits clean. Human-directed run: the repo claim held by `release-docs-polish-learn-paths` was explicitly overridden by the maintainer; file-level overlap with that task's uncommitted work is zero.

## API Changes
None — docs-only.

## Test Plan
- [x] Colab-URL audit: 0 problems in PyAutoGalaxy after fix
- [x] `heart/checks/url_check.sh` (incl. new phase-1 patterns): CLEAN
- [x] Post-merge central URL sweep dispatch to confirm the Colab rot class is gone ecosystem-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)
