### PR TITLE
docs: shared PyAuto brand layer for the Furo docs

### DIFF
--- a/docs/_static/pyauto.css
+++ b/docs/_static/pyauto.css
@@ -1,0 +1,32 @@
+/* PyAuto shared docs brand layer — identical file in PyAutoFit, PyAutoGalaxy,
+   PyAutoLens (docs/_static/pyauto.css). The per-project accent is set via
+   Furo's color-brand-* variables in each repo's conf.py; this file carries
+   the elements common to the whole stack. */
+
+/* The PyAuto family signature: a thin gradient strip across the top of every
+   docs page, running through the three stack accents (Fit / Galaxy / Lens). */
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #c2410c 0%, #0f766e 50%, #7c4dff 100%);
+  z-index: 1000;
+  pointer-events: none;
+}
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"])::before {
+    background: linear-gradient(90deg, #f28c38 0%, #2dd4bf 50%, #9d7aff 100%);
+  }
+}
+body[data-theme="dark"]::before {
+  background: linear-gradient(90deg, #f28c38 0%, #2dd4bf 50%, #9d7aff 100%);
+}
+
+/* Project wordmark in the sidebar. */
+.sidebar-brand-text {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,6 +124,20 @@ add_function_parentheses = False
 
 language = "en"
 
+html_static_path = ["_static"]
+html_css_files = ["pyauto.css"]
+
+html_theme_options = {
+    "light_css_variables": {
+        "color-brand-primary": "#0f766e",
+        "color-brand-content": "#0f766e",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#2dd4bf",
+        "color-brand-content": "#2dd4bf",
+    },
+}
+
 from sphinx.builders.html import StandaloneHTMLBuilder
 
 StandaloneHTMLBuilder.supported_image_types = ["image/gif", "image/png", "image/jpeg"]


### PR DESCRIPTION
## Summary
Phase B of the docs middle path (PyAutoLabs/pyautolabs.github.io#1; census + decision record PyAutoLabs/PyAutoFit#1341). Adds the stack-wide `docs/_static/pyauto.css` — identical file in PyAutoFit/PyAutoGalaxy/PyAutoLens: the PyAuto family gradient strip across the top of every docs page (the three stack accents) and sidebar wordmark styling — plus this project's own Furo accent (teal `#0f766e` light / `#2dd4bf` dark) via `light_css_variables`/`dark_css_variables`. 

Pairs with the new front door at https://pyautolabs.github.io (phase C, same palette). Zero-cost per the decision record: `*.readthedocs.io` stays canonical.

## API Changes
None — docs styling only.

## Test Plan
- [ ] Suite: 962 passed (full, worktree)
- [ ] Sphinx build: warning count unchanged at the baseline (105); `pyauto.css` deployed into `_static`, brand variables present in rendered HTML
- [ ] `docs` CI check (phase A) green on this PR

## Validation checklist (--auto run)
- Effective level: supervised (header: supervised, cap: docs ≤ medium → safe)
- Plan: on the issue (pyautolabs.github.io#1), written at launch (human directive: \"do everything else you can now, then stop for the night\")
- Gate: tests 962 passed · smoke n/a (docs styling only) · review CLEAN · Heart YELLOW — reason set verified identical to the set the human acked in-session earlier tonight (rtd-hygiene ship); treated as launch-time ack for this launch, disclosed here for validation
- PyAutoFit leg only: EP worktree claims overridden per the human's in-session direction earlier tonight (\"they don't clash\"); file disjointness re-verified
- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

<details>
<summary>Full API Changes (for automation & release notes)</summary>

None — files touched: `docs/_static/pyauto.css` (new), `docs/conf.py`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GziFkivBHz1d11eFYUszmy