### PR TITLE
refactor: use paths.preserve_in_zip for the galaxy-image cache (#1389 phase 2)

### DIFF
--- a/autogalaxy/analysis/adapt_images/adapt_images.py
+++ b/autogalaxy/analysis/adapt_images/adapt_images.py
@@ -76,29 +76,6 @@ def _galaxy_image_dict_from_cache(cache_path) -> Optional[Dict]:
     return galaxy_name_image_dict
 
 
-def _append_to_search_zip(paths, file_path):
-    """
-    Also add a cache file into the search's ``.zip`` archive.
-
-    A resumed search's ``paths.restore()`` deletes the output directory and
-    re-extracts the zip, so a cache written only to ``files/`` after the search
-    completed would be destroyed by the next resume. Appending it to the zip
-    makes it a permanent part of the completed output (each later resume
-    re-extracts and re-zips it with everything else).
-    """
-    import zipfile
-    from pathlib import Path
-
-    zip_path = getattr(paths, "_zip_path", None)
-    output_path = getattr(paths, "output_path", None)
-    if zip_path is None or output_path is None or not Path(zip_path).exists():
-        return
-    arcname = str(Path(file_path).relative_to(output_path))
-    with zipfile.ZipFile(zip_path, "a") as f:
-        if arcname not in f.namelist():
-            f.write(file_path, arcname)
-
-
 def _galaxy_image_dict_to_cache(cache_path, galaxy_name_image_dict: Dict, paths):
     """
     Persist the raw per-galaxy image dictionary to the result's cache file, in
@@ -117,7 +94,7 @@ def _galaxy_image_dict_to_cache(cache_path, galaxy_name_image_dict: Dict, paths)
         header_dict=next(iter(galaxy_name_image_dict.values())).mask.header_dict,
     )
     hdu_list.writeto(cache_path, overwrite=True)
-    _append_to_search_zip(paths, cache_path)
+    paths.preserve_in_zip(cache_path)
 
 
 def galaxy_name_image_dict_via_result_from(

--- a/test_autogalaxy/analysis/test_adapt_images.py
+++ b/test_autogalaxy/analysis/test_adapt_images.py
@@ -114,6 +114,9 @@ class _StubCachePaths:
     def __init__(self, files_path):
         self._files_path = files_path
 
+    def preserve_in_zip(self, file_path):
+        """No zip in the stub — mirrors AbstractPaths' no-zip no-op."""
+
 
 class _StubCacheResult:
     """Duck-typed result for `galaxy_name_image_dict_via_result_from`."""


### PR DESCRIPTION
## Summary

Phase 2 of PyAutoFit#1389 (autogalaxy leg): the resume fast-path galaxy-image cache now calls the public `AbstractPaths.preserve_in_zip` (PyAutoFit#1390, merged) and the private `_append_to_search_zip` helper is deleted. Behaviour identical — validated end-to-end via the `autolens_profiling` `pipeline_resume` recipe (cold 159s → resume ~11–13s).

## API Changes

None public. Private `_append_to_search_zip` removed from `autogalaxy/analysis/adapt_images/adapt_images.py` (its one external consumer, PyAutoLens, switches in the companion PR).

## Test Plan
- [x] `test_adapt_images.py` file green (stub gains the no-op method)
- [x] Full `test_autogalaxy/` suite green

Companion: PyAutoLens PR (same branch name). Part of PyAutoFit#1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
