### PR TITLE
chore: rename PyAutoConf → PyAutoNerves in docs/prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ import `autolens` — lensing lives one layer up.
 
 ## Related repos
 
-- **Source siblings:** PyAutoConf, PyAutoArray, PyAutoFit (upstream);
+- **Source siblings:** PyAutoNerves, PyAutoArray, PyAutoFit (upstream);
   PyAutoLens (downstream — builds multi-plane lensing on autogalaxy).
 - **autogalaxy_workspace** — runnable tutorials/examples (`../autogalaxy_workspace`).
 - **autogalaxy_workspace_test** — integration + JAX/likelihood parity scripts.

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -11,7 +11,7 @@ the [config directory of the workspace](https://github.com/PyAutoLabs/autogalaxy
 By default, **PyAutoGalaxy** looks for the config files in a `config` folder in the current working directory, which is
 why we run autogalaxy scripts from the `autogalaxy_workspace` directory.
 
-The configuration path can also be set manually in a script using the project **PyAutoConf** and the following
+The configuration path can also be set manually in a script using the project **PyAutoNerves** and the following
 command (the path to the `output` folder where the results of a non-linear search are stored is also set below):
 
 ```bash

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -22,7 +22,7 @@ our [building from source installation guide](https://pyautogalaxy.readthedocs.i
 
 **PyAutoGalaxy** has the following dependencies:
 
-**PyAutoConf** <https://github.com/PyAutoLabs/PyAutoConf>
+**PyAutoNerves** <https://github.com/PyAutoLabs/PyAutoNerves>
 
 **PyAutoFit** <https://github.com/PyAutoLabs/PyAutoFit>
 

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -93,7 +93,7 @@ git clone https://github.com/PyAutoLabs/PyAutoArray
 git clone https://github.com/PyAutoLabs/PyAutoGalaxy
 ```
 
-Next, install **PyAutoConf** via pip:
+Next, install **PyAutoNerves** via pip:
 
 ```bash
 pip install autonerves

--- a/llms.txt
+++ b/llms.txt
@@ -17,4 +17,4 @@
 
 ## Ecosystem
 
-- Built on PyAutoArray (data structures) + PyAutoFit (inference) + PyAutoConf (config); used by PyAutoLens, which builds multi-plane lensing on it.
+- Built on PyAutoArray (data structures) + PyAutoFit (inference) + PyAutoNerves (config); used by PyAutoLens, which builds multi-plane lensing on it.


### PR DESCRIPTION
## What

Update the "source siblings / related repos" references from PyAutoConf to PyAutoNerves following the GitHub repo rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_