### PR TITLE
fix: SersicCore.intensity_prime ZeroDivisionError on effective_radius=0 (#514)

### DIFF
--- a/autogalaxy/profiles/light/standard/sersic_core.py
+++ b/autogalaxy/profiles/light/standard/sersic_core.py
@@ -64,9 +64,9 @@ class SersicCore(Sersic):
             * (2.0 ** (-self.gamma / self.alpha))
             * xp.exp(
                 self.sersic_constant
-                * (
-                    ((2.0 ** (1.0 / self.alpha)) * self.radius_break)
-                    / self.effective_radius
+                * xp.divide(
+                    (2.0 ** (1.0 / self.alpha)) * self.radius_break,
+                    self.effective_radius,
                 )
                 ** (1.0 / self.sersic_index)
             )

--- a/test_autogalaxy/profiles/light/standard/test_sersic_core.py
+++ b/test_autogalaxy/profiles/light/standard/test_sersic_core.py
@@ -1,4 +1,5 @@
 from __future__ import division, print_function
+import numpy as np
 import pytest
 
 import autogalaxy as ag
@@ -20,6 +21,28 @@ def test__image_2d_from__elliptical__ell_comps_nonzero__correct_value():
     image = lp.image_2d_from(grid=ag.Grid2DIrregular([[0.0, 0.1]]))
 
     assert image == pytest.approx(0.0255173, 1.0e-4)
+
+
+def test__intensity_prime__effective_radius_zero__non_finite_not_zero_division():
+    # A degenerate `effective_radius=0` (e.g. a non-linear search proposing an
+    # unphysical value, or a wavelength-relation instance evaluating to 0) must
+    # yield a non-finite value the search resamples on, not a hard
+    # ``ZeroDivisionError`` — matching every other profile's array division.
+    lp = ag.lp.SersicCore(
+        effective_radius=0.0,
+        sersic_index=4.0,
+        radius_break=0.01,
+        intensity=0.1,
+        gamma=1.0,
+        alpha=1.0,
+    )
+
+    value = lp.intensity_prime()
+
+    assert not np.isfinite(value)
+
+    # The full image path must not raise either.
+    lp.image_2d_from(grid=ag.Grid2DIrregular([[0.0, 0.1]]))
 
 
 def test__image_2d_from__spherical_profile__matches_elliptical_with_zero_ellipticity():


### PR DESCRIPTION
## Summary

`SersicCore.intensity_prime` raised `ZeroDivisionError` when `effective_radius == 0` because it divided a **Python scalar** with a plain `/`. Every other profile (e.g. `Sersic.image_2d_via_radii`, `sersic.py:99/157`) divides a **numpy array** by `effective_radius`, yielding `inf` — a non-finite value the non-linear search resamples on — rather than crashing. This switches the scalar division to `xp.divide` so `SersicCore` behaves identically (numpy/jax parity; same raise-vs-resample lineage as PyAutoLens#607).

Surfaced by `autolens_workspace multi/features/wavelength_dependence/modeling` (split out from autolens_workspace#300), whose `effective_radius = wavelength*m + c` relation — `m ~ U(-0.1,0.1)`, `c ~ U(-10,10)`, both symmetric about 0 — yields `effective_radius=0` at the test-mode median instance. `alpha` was never the cause (Constant 3.0; probe-verified).

## API Changes

No signature changes. One **behaviour** change:

<details>
<summary>Changed Behaviour</summary>

- `SersicCore.intensity_prime()` (and hence `SersicCore` / `SersicCoreSph` image evaluation) with `effective_radius <= 0` now returns a **non-finite** value (`inf`/`nan`) instead of raising `ZeroDivisionError`. Callers that fit `SersicCore` get the standard non-finite → `FitException`/resample path rather than a hard crash. The return is now a numpy/jax scalar (was a Python `float`) for the affected term; numeric results for physical `effective_radius > 0` are unchanged (existing exact-value tests still pass).

**Migration:** none required. Any downstream code that relied on the `ZeroDivisionError` (there is none in the stack) should instead check `np.isfinite`.
</details>

## Test Plan
- [x] `test_autogalaxy/profiles/light/standard/test_sersic_core.py` — new numpy-only test: `effective_radius=0.0` → non-finite `intensity_prime()`, no raise (3 passed)
- [x] `test_autogalaxy/profiles/light/` — 94 passed
- [x] Full `test_autogalaxy/` — 1004 passed
- [x] Downstream: `autolens_workspace multi/features/wavelength_dependence/modeling` runs green under the CI smoke env (workspace PR follows)

## Downstream
Workspace follow-up (autolens_workspace, ships after this merges): add the missing auto-simulate block to the multi-wavelength script + drop its `no_run.yaml` marker.

Generated by the PyAutoLabs agent workflow.