### PR TITLE
docs: rectangular mesh users must cite Enzi et al. 2026 (RTU grids)

### DIFF
--- a/docs/general/citations.md
+++ b/docs/general/citations.md
@@ -72,6 +72,32 @@ also be cited:
 
 The package is available at <https://github.com/GragasLab/nufftax>.
 
+## Rectangular Mesh (Pixelized Reconstructions)
+
+If you reconstruct a galaxy using the adaptive rectangular meshes (`RectangularAdaptDensity` or
+`RectangularAdaptImage`), you **must cite** the following paper <https://arxiv.org/abs/2606.30620> under citation
+key `Enzi2026`. The mesh's adaptive coordinate transform implements the ray-guided transformed uniform (RTU)
+grid formulation this paper introduces, which is what makes the pixelization adaptive and fully
+auto-differentiable:
+
+```bibtex
+@article{Enzi2026,
+  author        = {Enzi, Wolfgang J. R. and Krawczyk, Coleman M. and Li, Tian and Collett, Thomas E.},
+  title         = {Gaussian processes on ray-guided transformed uniform grids for fast, flexible, and auto-differentiable adaptive source reconstruction in lens modelling},
+  journal       = {MNRAS, submitted},
+  eprint        = {2606.30620},
+  archivePrefix = {arXiv},
+  primaryClass  = {astro-ph.GA},
+  year          = {2026},
+  url           = {https://arxiv.org/abs/2606.30620},
+}
+```
+
+Note that **PyAutoGalaxy** pairs the RTU grid with its own regularization schemes (e.g. `reg.Constant`,
+`reg.Adapt`) rather than the Gaussian-process prior used in the paper, so quantitative results are not
+directly comparable between the two implementations. The `RectangularUniform` mesh performs no RTU transform,
+so this citation is not required when only the uniform mesh is used.
+
 ## Dynesty
 
 If you used the nested sampling algorithm Dynesty, please follow the citation instructions [on the dynesty readthedocs](https://dynesty.readthedocs.io/en/latest/references.html).

--- a/files/citations.bib
+++ b/files/citations.bib
@@ -367,3 +367,14 @@ abstractNote={<p>This is a bug release mostly concerning the checkpointing. Chec
 publisher={Zenodo},
 author={Sergey Koposov and Josh Speagle and Kyle Barbary and Gregory Ashton and Ed Bennett and Johannes Buchner
 and Carl Scheffler and Ben Cook and Colm Talbot and James Guillochon and et al.}, year={2023}, month={Jun} }
+
+@article{Enzi2026,
+  author        = {Enzi, Wolfgang J. R. and Krawczyk, Coleman M. and Li, Tian and Collett, Thomas E.},
+  title         = {Gaussian processes on ray-guided transformed uniform grids for fast, flexible, and auto-differentiable adaptive source reconstruction in lens modelling},
+  journal       = {MNRAS, submitted},
+  eprint        = {2606.30620},
+  archivePrefix = {arXiv},
+  primaryClass  = {astro-ph.GA},
+  year          = {2026},
+  url           = {https://arxiv.org/abs/2606.30620},
+}


### PR DESCRIPTION
## Summary
Documentation + bibliography only. Adds a **Rectangular Mesh** section to `docs/general/citations.md` stating that analyses using the adaptive rectangular meshes (`RectangularAdaptDensity` / `RectangularAdaptImage`) **must cite** Enzi et al. 2026 (arXiv:2606.30620, MNRAS submitted) under key `Enzi2026` — the mesh's adaptive coordinate transform implements that paper's ray-guided transformed uniform (RTU) grid formulation. Notes that `RectangularUniform` performs no RTU transform (citation not required) and that the regularization differs from the paper (our `reg.*` schemes vs their Gaussian-process prior). Adds the matching `Enzi2026` entry to `files/citations.bib`.

Part of PyAutoLabs/PyAutoArray#402 (companion to PyAutoLabs/PyAutoArray#403).

## API Changes
None — internal changes only.

## Test Plan
- [ ] Docs CI build renders the new section (myst markdown matches the neighbouring Jax-Zero-Contour / NUFFTax sections)

Generated by the PyAutoLabs agent workflow.