### PR TITLE
docs: make getting started assistant-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@
 
 ## Getting Started
 
-The following links are useful for new starters:
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+The following human-readable documentation and examples are also useful for new starters:
 
 - [The PyAutoGalaxy readthedocs](https://pyautogalaxy.readthedocs.io/en/latest), which includes [an overview of PyAutoGalaxy's core features](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html).
 - [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,9 @@ substitutions:
 
 # Getting Started
 
-The following links are useful for new starters:
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+The following human-readable documentation and examples are also useful for new starters:
 
 - [The PyAutoGalaxy readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/), which includes [an overview of PyAutoGalaxy's core features](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html).
 - [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -8,6 +8,12 @@ Depending on the data you use, the analysis you perform may differ significantly
 The autogalaxy_workspace contains a suite of example Jupyter Notebooks, organised by dataset type. To help you find
 the most appropriate starting point, answer one simple question:
 
+## AI Assistant
+
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+The rest of this human-readable guide helps you find the most appropriate example notebook for your science case.
+
 ## What Dataset Type?
 
 You now need to decide what type of data you are interested in:


### PR DESCRIPTION
## Summary
- Put the PyAutoGalaxy AI Assistant first in README and Read the Docs getting-started guidance.
- Present conversation agents and coding agents as two ways to use one assistant.
- Introduce the remaining resources as human-readable documentation and examples while preserving existing Colab and workspace links.

## API Changes
None — internal changes only. Documentation wording only; the public Python API is unchanged. See full details below.

## Test Plan
- [x] `python -m pytest test_autogalaxy/ -x`
- [x] `python -m sphinx --keep-going -b html docs <temporary-output-directory>`
- [x] Confirmed the scoped files contain none of the retired chat/agentic/Three Ways terminology
- [x] Confirmed `https://github.com/PyAutoLabs/autogalaxy_assistant` is the intended canonical URL; its temporary 404 was explicitly accepted by the maintainer in PyAutoLens issue #645 pending creation of the assistant later today

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- None.

### Added
- None.

### Renamed
- None.

### Changed Signature
- None.

### Changed Behaviour
- None.

### Migration
- None required.

</details>

Generated by the PyAutoLabs agent workflow.
