### PR TITLE
docs: clarify assistant and documentation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@
 
 ## Getting Started
 
+### PyAutoGalaxy AI Assistant
+
 The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+### Human-Readable Documentation and Examples
 
 The following human-readable documentation and examples are also useful for new starters:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,11 @@ substitutions:
 
 # Getting Started
 
+## PyAutoGalaxy AI Assistant
+
 The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+## Human-Readable Documentation and Examples
 
 The following human-readable documentation and examples are also useful for new starters:
 

--- a/docs/overview/overview_1_start_here.md
+++ b/docs/overview/overview_1_start_here.md
@@ -2,6 +2,12 @@
 
 # Start Here
 
+## PyAutoGalaxy AI Assistant
+
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+## Human-Readable Overview
+
 **PyAutoGalaxy** is software for analysing the morphologies and structures of galaxies:
 
 ```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/paper/hstcombined.png

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -2,17 +2,17 @@
 
 # New User Guide
 
+## PyAutoGalaxy AI Assistant
+
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+## Human-Readable Guide
+
 **PyAutoGalaxy** can analyse galaxies for different types of data (e.g. CCD imaging and interferometer observations).
 Depending on the data you use, the analysis you perform may differ significantly.
 
 The autogalaxy_workspace contains a suite of example Jupyter Notebooks, organised by dataset type. To help you find
 the most appropriate starting point, answer one simple question:
-
-## AI Assistant
-
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
-
-The rest of this human-readable guide helps you find the most appropriate example notebook for your science case.
 
 ## What Dataset Type?
 


### PR DESCRIPTION
## Summary
- separate the PyAutoGalaxy AI Assistant and human-readable documentation into clearly headed onboarding routes
- put the AI Assistant first on the Read the Docs Start Here page
- split assistant guidance from the conventional New User Guide content

## API Changes
None — documentation-only changes.

## Test Plan
- [x] `git diff --check`
- [x] `python -m sphinx -b html docs /tmp/assistant_docs_hierarchy_pyautogalaxy`
- [x] `python -m pytest test_autogalaxy/ -x`
- [x] Confirm generated HTML contains the new headings in the intended order

Generated by the PyAutoLabs agent workflow.
