### PR TITLE
docs: link Colab introduction to workspace start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyAutoGalaxy: Open-Source Multi Wavelength Galaxy Structure & Morphology
 
-[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb)
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/start_here.ipynb)
 [![Documentation Status](https://readthedocs.org/projects/pyautogalaxy/badge/?version=latest)](https://pyautogalaxy.readthedocs.io/en/latest/?badge=latest)
 [![Tests](https://github.com/PyAutoLabs/PyAutoGalaxy/actions/workflows/main.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoGalaxy/actions)
 [![Build](https://github.com/PyAutoLabs/PyAutoHands/actions/workflows/release.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoHands/actions)
@@ -14,7 +14,7 @@
 
 [Installation Guide](https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html) |
 [readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/index.html) |
-[Introduction on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb) |
+[Introduction on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/start_here.ipynb) |
 [HowToGalaxy](https://pyautogalaxy.readthedocs.io/en/latest/howtogalaxy/howtogalaxy.html)
 
 **PyAutoGalaxy** is software for analysing the morphologies and structures of galaxies:
@@ -36,7 +36,7 @@ The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_ass
 The following human-readable documentation and examples are also useful for new starters:
 
 - [The PyAutoGalaxy readthedocs](https://pyautogalaxy.readthedocs.io/en/latest), which includes [an overview of PyAutoGalaxy's core features](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
+- [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
 - [The autogalaxy_workspace GitHub repository](https://github.com/PyAutoLabs/autogalaxy_workspace): example scripts covering every **PyAutoGalaxy** use case.
 - [The HowToGalaxy GitHub repository](https://github.com/PyAutoLabs/HowToGalaxy): a Jupyter notebook lecture series teaching galaxy modeling from the ground up.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_ass
 The following human-readable documentation and examples are also useful for new starters:
 
 - [The PyAutoGalaxy readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/), which includes [an overview of PyAutoGalaxy's core features](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
+- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
 - [The autogalaxy_workspace GitHub repository](https://github.com/PyAutoLabs/autogalaxy_workspace): example scripts covering every **PyAutoGalaxy** use case.
 - [The HowToGalaxy GitHub repository](https://github.com/PyAutoLabs/HowToGalaxy): a Jupyter notebook lecture series teaching galaxy modeling from the ground up.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -75,7 +75,7 @@ massively parallel model-fitting and an SQLite3 database that allows large suite
 queried and analysed. Accompanying `PyAutoGalaxy` is the [autogalaxy workspace](https://github.com/PyAutoLabs/autogalaxy_workspace),
 which includes example scripts and galaxy datasets covering every use case. The [`HowToGalaxy`](https://github.com/PyAutoLabs/HowToGalaxy)
 repository provides a separate Jupyter notebook lecture series which introduces non-experts to galaxy morphology studies using `PyAutoGalaxy`. Readers can try `PyAutoGalaxy` right now by going 
-to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/notebooks/imaging/start_here.ipynb) or 
+to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.23.1/start_here.ipynb) or
 checkout the [readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/) for a complete overview of `PyAutoGalaxy`'s 
 features.
 


### PR DESCRIPTION
## Summary
Route generic PyAutoGalaxy Colab introduction links to the workspace-root `start_here.ipynb` instead of the imaging-specific notebook. Explicit links for the imaging tutorial remain unchanged.

## API Changes
None — internal changes only.

## Test Plan
- [ ] `python -m pytest test_autogalaxy/ -x`
- [x] Verified the `2026.7.23.1` root notebook exists and contains `setup_colab.for_autogalaxy(...)`
- [x] Confirmed introductory links target the root notebook and imaging-specific links remain unchanged
- [x] `git diff --check`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

No public API changes. Documentation links only.

</details>

Generated by the PyAutoLabs agent workflow.
