### PR TITLE
fix: make the dPIEMass ellipticity→ell_comps conversion JAX-tracer safe

### DIFF
--- a/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_mass.py
+++ b/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_mass.py
@@ -41,6 +41,26 @@ def _b0_from_lenstool_sigma(
     return 6.0 * 648000.0 * (sigma / c_km_s) ** 2 * (d_ls / d_s)
 
 
+def _xp_from(*values):
+    """
+    numpy, unless any input is a JAX array/tracer — constructor arguments carry no
+    ``xp`` threading, so when a free parameter arrives traced (model-fitting under
+    ``jax.jit``) the backend must be inferred from the values themselves.
+    """
+    try:
+        from jax import Array
+        from jax.core import Tracer
+    except Exception:
+        return np
+
+    if any(isinstance(value, (Array, Tracer)) for value in values):
+        import jax.numpy as jnp
+
+        return jnp
+
+    return np
+
+
 # Within this profile family, PIEMass, dPIEMassB0, and dPIEMassB0Sph are directly ported from Lenstool's C code, and have been thoroughly annotated and adapted for PyAutoLens.
 # dPIEMass and dPIEMassSph (the default profiles) expose the same physics in Lenstool's native parameterization.
 # The dPIEPotential and dPIEPotentialSph profiles are modified from the original `dPIEPotential` and `dPIEPotentialSph`, which were implemented to PyAutoLens by Jackson O'Donnell.
@@ -621,8 +641,9 @@ class dPIEMassB0(MassProfile):
 
             cosmology = Planck15()
 
-        axis_ratio = np.sqrt((1.0 - ellipticity) / (1.0 + ellipticity))
-        ell_comps = convert.ell_comps_from(axis_ratio=axis_ratio, angle=angle_pos)
+        xp = _xp_from(ellipticity, angle_pos)
+        axis_ratio = xp.sqrt((1.0 - ellipticity) / (1.0 + ellipticity))
+        ell_comps = convert.ell_comps_from(axis_ratio=axis_ratio, angle=angle_pos, xp=xp)
 
         b0 = _b0_from_lenstool_sigma(
             sigma=sigma,
@@ -1186,8 +1207,9 @@ class dPIEMass(dPIEMassB0):
         # them only so af.Model composition works.
         cosmology = FlatLambdaCDM(H0=H0, Om0=Om0)
 
-        axis_ratio = np.sqrt((1.0 - ellipticity) / (1.0 + ellipticity))
-        ell_comps = convert.ell_comps_from(axis_ratio=axis_ratio, angle=angle_pos)
+        xp = _xp_from(ellipticity, angle_pos)
+        axis_ratio = xp.sqrt((1.0 - ellipticity) / (1.0 + ellipticity))
+        ell_comps = convert.ell_comps_from(axis_ratio=axis_ratio, angle=angle_pos, xp=xp)
 
         b0 = _b0_from_lenstool_sigma(
             sigma=sigma,


### PR DESCRIPTION
## Summary

Fixes the 2026-07-26 nightly release failure (PyAutoBrain [nightly run](https://github.com/PyAutoLabs/PyAutoBrain/actions/runs/30189574970) → Stage 3 release-fidelity [Heart run](https://github.com/PyAutoLabs/PyAutoHeart/actions/runs/30189764840), job `run_scripts (3.12, autolens, group)`).

`dPIEMass.__init__` (and `dPIEMassB0.from_lenstool`) converted the Lenstool `ellipticity`/`angle_pos` parameterization to `ell_comps` via `np.sqrt` and an un-threaded `convert.ell_comps_from`. Under a real jitted model-fit those arguments arrive as JAX tracers — `ellipticity` and `angle_pos` are free parameters — and the `np.*` ops raise `TracerArrayConversionError`. The new `autolens_workspace` `group/features/group_halo/modeling.py` (merged Sat 2026-07-25 evening) is the first script to fit `dPIEMass` with free ellipticity priors, so last night's Stage 3 run was the first to hit it. The PR smoke gate never sees this because `PYAUTO_TEST_MODE=2` bypasses the sampler.

## The fix

Constructors carry no `xp` threading (their signatures are the model-composition contract — adding an `xp` argument would surface as a bogus model parameter and break serialization), so the backend is inferred from the argument values via a small `_xp_from(*values)` helper — the same idiom as `is_jax` in `gnfw_virial_mass_conc.py` — and threaded through the `sqrt` and `convert.ell_comps_from` calls in both `dPIEMass.__init__` and `dPIEMassB0.from_lenstool`. The branch depends only on the Python type of the value, never a traced value, and returns `np` unless a JAX array/tracer actually arrives, so the NumPy path is unchanged.

## Verification

- `scripts/group/features/group_halo/modeling.py` now runs end-to-end under the exact `profile_release.yaml` environment (`PYAUTO_TEST_MODE=1`, real Nautilus under JAX): both fits complete, Δ log Z = +35.8, exit 0. Previously reproduced the exact `TracerArrayConversionError` at `dual_pseudo_isothermal_mass.py:1189`.
- Every other script touching `dPIEMass`/`from_lenstool` passes under its release-profile env: `group/features/group_halo/simulator.py`, `cluster/mass_parameterizations{,_pyautolens}.py`, `cluster/lenstool/{data,modeling,parameterization_mapping}.py`, `cluster/csv_api.py`, `guides/profiles/{mass,light_and_mass_profiles}.py`, and `autolens_workspace_test` `cluster/lenstool_parity.py` + `misc/mass/total.py` (real mode — numerical parity vs the Lenstool reference is unaffected).
- Full `test_autogalaxy/` suite: 996 passed, 1 skipped.

## Downstream impact

None expected: no public-API change, NumPy behaviour identical. PyAutoLens re-exports these profiles unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uj1vtq2eV7kRg3r5C7fDb

---
_Generated by [Claude Code](https://claude.ai/code/session_016uj1vtq2eV7kRg3r5C7fDb)_