### PR TITLE
feat: add zero-parameter ps.PointSolved point-source profile

### DIFF
--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -499,6 +499,14 @@ class LensCalc:
         It is computed from `hessian_from`, so it supports both uniform and irregular
         grids and accepts the same `xp` parameter for JAX acceleration.
 
+        **Row/column convention**: the returned 2x2 list is in **(x, y)** row/column order
+        (``a11``/``a22`` above are the xx/yy components), *not* the (y, x) order used by
+        every position/grid array elsewhere in this project (e.g. ``grid[:, 0]`` is y).
+        Callers that only use the scalar determinant (e.g. ``magnification_2d_via_hessian_from``)
+        are unaffected, since ``det`` is invariant under a simultaneous row/column swap. Callers
+        that use the individual components as a matrix alongside (y, x)-ordered vectors (e.g. a
+        precision/covariance transform) must re-index first: `A_yx = [[a22, a21], [a12, a11]]`.
+
         Parameters
         ----------
         grid

--- a/autogalaxy/profiles/point_sources.py
+++ b/autogalaxy/profiles/point_sources.py
@@ -11,3 +11,25 @@ class PointFlux(Point):
         super().__init__(centre=centre)
 
         self.flux = flux
+
+
+class PointSolved:
+    """
+    A point source profile with no free parameters.
+
+    Unlike `Point` and `PointFlux`, `PointSolved` has no `centre` (and no `flux`)
+    attribute at all, so it contributes zero dimensions to a model's prior count. It is
+    intended to be paired, via name pairing, with one of the `*Solved` fit classes in
+    `autolens.point.fit` (e.g. `FitPositionsSourceSolved`, `FitPositionsImagePairAllSolved`,
+    `FitPositionsImagePairRepeatSolved`, `FitFluxesSolved`), which analytically solve for
+    the source-plane centre (and, if the dataset has fluxes, the source flux) that
+    maximizes the likelihood given the current tracer, rather than sampling these
+    quantities as free parameters.
+
+    Using `PointSolved` with a fit class that is not one of the `*Solved` variants, or
+    using `Point` / `PointFlux` with a `*Solved` fit class, is an invalid combination and
+    raises an informative `PointExtractionException` (see `autolens.point.fit.abstract`
+    and `autolens.point.fit.fluxes`).
+    """
+
+    pass

--- a/test_autogalaxy/profiles/test_point_sources.py
+++ b/test_autogalaxy/profiles/test_point_sources.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 import numpy as np
 
+import autofit as af
 import autogalaxy as ag
 
 grid = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [2.0, 4.0]])
@@ -12,3 +13,37 @@ class TestPointFlux:
 
         assert point_source.centre == (0.0, 0.0)
         assert point_source.flux == 0.1
+
+
+class TestPointSolved:
+    def test__constructor__no_parameters(self):
+        point_source = ag.ps.PointSolved()
+
+        assert not hasattr(point_source, "centre")
+        assert not hasattr(point_source, "flux")
+
+    def test__model_composition__contributes_zero_free_parameters(self):
+        # A zero-parameter class must compose fine under `af.Model` without a config
+        # entry (its priors dict is derived from `__init__`, which has no arguments) and
+        # must not add to the model's overall prior count.
+        model = af.Model(ag.Galaxy, redshift=1.0, point_0=ag.ps.PointSolved)
+
+        assert model.prior_count == 0
+
+        instance = model.instance_from_prior_medians()
+
+        assert isinstance(instance.point_0, ag.ps.PointSolved)
+
+    def test__model_composition__prior_count_unchanged_by_other_free_parameters(self):
+        # A `PointSolved` component contributes 0 to the total, regardless of what else
+        # is on the galaxy (regression guard for the component-count summing).
+        model = af.Model(
+            ag.Galaxy,
+            redshift=1.0,
+            point_0=ag.ps.PointSolved,
+            mass=ag.mp.IsothermalSph,
+        )
+
+        mass_only_model = af.Model(ag.Galaxy, redshift=1.0, mass=ag.mp.IsothermalSph)
+
+        assert model.prior_count == mass_only_model.prior_count


### PR DESCRIPTION
## Summary
Adds `ag.ps.PointSolved` — a zero-parameter point-source profile for the new analytically-solved point-source fits (PyAutoLabs/PyAutoLens#657, phase 2 of 5, from Lombardi 2024 arXiv:2406.15280 §5.1). Composing it via `af.Model` contributes 0 free parameters: the source-plane centre (and flux, when the dataset has fluxes) is solved analytically by the paired PyAutoLens `*Solved` fit classes instead of being sampled. Also documents a convention landmine found during this work: `LensCalc.jacobian_from` returns its 2x2 components in (x, y) row/column order, against the codebase's universal (y, x) convention — invisible to existing determinant-only callers, but silently corrupting for any tensor consumer (docstring warning added; no behaviour change).

## API Changes
Added `ag.ps.PointSolved` (zero-parameter profile). No other public-surface changes; `jacobian_from` change is docstring-only.
See full details below.

## Test Plan
- [ ] `pytest test_autogalaxy/` (1009 passed locally, incl. new `PointSolved` construction + `af.Model` prior-count tests)

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `ag.ps.PointSolved` — zero-parameter point-source profile; pair with the PyAutoLens `FitPositions*Solved` / `FitFluxesSolved` / `FitTimeDelaysSolved` fit classes. Requires no prior-config entry (verified: `af.Model` composition yields `prior_count == 0`).

</details>

Companion PRs: PyAutoArray (merge first) + PyAutoLens branches `feature/point-source-chi-squared-variants`.

Generated by the PyAutoLabs agent workflow.