### PR TITLE
fix: gate autofit[jax] to python>=3.11 in the jax extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,14 @@ jax = [
     # searches (MultiStartAdam / MultiStartProdigy) import. Without it the chain
     # autolens[jax] -> autogalaxy[jax] stopped at autonerves[jax], so `pip
     # install autolens[jax]` left those searches raising ImportError.
-    "autofit[jax]",
+    #
+    # Marked >= 3.11 so this entry matches every other member of the extra.
+    # autofit's own optax entry only gained that marker on main; any *released*
+    # autofit still expands autofit[jax] to an unmarked optax, and resolving
+    # that below 3.11 sends pip backtracking to `resolution-too-deep`. Gating
+    # here makes the chain correct whichever autofit version pip resolves,
+    # rather than only when autofit comes from a source checkout.
+    "autofit[jax]; python_version >= '3.11'",
     "jax_zero_contour>=2.0.0,<3.0.0; python_version >= '3.11'"
 ]
 optional = [


### PR DESCRIPTION
Follow-up to #530, raised by an independent **Codex review** of that commit.

## The gap

#530 pointed `autogalaxy[jax]` at `autofit[jax]` so optax follows the jax chain. PyAutoFit#1426 then marked autofit's own optax entry `python_version >= '3.11'`, after an unmarked optax sent pip to `resolution-too-deep` and took every 3.9 leg of `python_matrix` red.

But that fix lives on **autofit's main**. Any *released* autofit still expands `autofit[jax]` to an unmarked optax — confirmed straight from PyPI:

```
autofit 2026.7.27.1  ->  'optax>=0.2.5; extra == "jax"'      # no marker
```

So `autogalaxy[jax]` was only safe when autofit came from a **source checkout**. That is exactly why CI went green while the released chain stayed exposed: `python_matrix` installs all five libraries with `-e ./PyAuto*`, so it resolves autofit from source and can never exercise this path.

Live exposure is narrow — installing autogalaxy/autolens from git `main` with `[jax]` on Python 3.9/3.10 — because today's PyPI users get released autogalaxy, which does not chain to `autofit[jax]` yet, and the next release ships both libraries at the same version. But the window is real until then, and the fix is one line.

## Change

```diff
-    "autofit[jax]",
+    "autofit[jax]; python_version >= '3.11'",
```

Now **every** member of the `jax` extra carries the same gate, so the extra is a clean no-op below 3.11 — exactly the pre-#530 behaviour — and correct on 3.11+ whichever autofit version pip resolves.

## API Changes

**None.** Packaging metadata only, and strictly narrowing. `autogalaxy[jax]` on 3.11+ resolves exactly as #530 intended; on 3.9/3.10 it resolves exactly as it did before #530.

## Verification

Built wheel metadata from this branch:

```
Requires-Dist: autofit[jax]; python_version >= "3.11" and extra == "jax"
Requires-Dist: jax_zero_contour<3.0.0,>=2.0.0; python_version >= "3.11" and extra == "jax"
```

Marker evaluation, both entries:

```
autofit           {'3.9': False, '3.10': False, '3.11': True, '3.12': True}
jax_zero_contour  {'3.9': False, '3.10': False, '3.11': True, '3.12': True}
```

## Lesson

Marker parity within an extra is load-bearing, and **a source-installed CI matrix cannot verify a released dependency chain**. An extra that mixes gated and ungated entries is only as correct as the version of its sibling that happens to resolve.
