### PR TITLE
docs: adapt-image cache is repaired on disk (PyAutoFit#1414)

### DIFF
--- a/autogalaxy/analysis/adapt_images/adapt_images.py
+++ b/autogalaxy/analysis/adapt_images/adapt_images.py
@@ -173,11 +173,10 @@ def galaxy_name_image_dict_via_result_from(
     ``analysis.dataset.mask`` and does not rebuild the maximum log likelihood fit, so the check costs nothing
     the cache was saving (PyAutoGalaxy#516).
 
-    Note that a stale cache is not *repaired* on disk: the recomputed images are written to the loose
-    ``files/`` folder, but ``Paths.preserve_in_zip`` only adds a member that is absent from the search's zip
-    and never replaces one, so the next ``restore()`` re-extracts the stale copy. Such a search therefore
-    misses the cache on every run rather than once — correct, but without the caching win until its output is
-    cleared (PyAutoFit#1414).
+    A stale cache is also *repaired* on disk: the recomputed images are written back to the loose ``files/``
+    folder and ``Paths.preserve_in_zip`` replaces the search's now-outdated zip member, so the next
+    ``restore()`` re-extracts the recomputed copy. A dataset change therefore costs one recompute rather than
+    one per run (PyAutoFit#1414).
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary

Docstring-only follow-up to PyAutoFit#1414 / PyAutoFit#1427.

`galaxy_name_image_dict_via_result_from` documented the stale-cache limitation as standing behaviour: the recomputed images were written to the loose `files/` folder, but `Paths.preserve_in_zip` only added a member absent from the search's zip and never replaced one, so the next `restore()` re-extracted the stale copy and the search missed its cache on every run. PyAutoFit#1427 makes `preserve_in_zip` replace an outdated member, so a dataset change now costs one recompute rather than one per run. This updates the paragraph to the repaired behaviour.

**Merge after PyAutoFit#1427** — the text describes that PR's behaviour.

## API Changes

None — internal changes only (docstring).

## Test Plan

- [x] `pytest test_autogalaxy` — 1009 passed
- [x] `pytest test_autogalaxy/analysis/test_adapt_images.py` — 8 passed

Generated by the PyAutoLabs agent workflow.