### PR TITLE
feat: require Python 3.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest t
 
 PRs must pass `pytest --cov` on the CI matrix (Python 3.12 **and** 3.13). There
 is no black/ruff/flake8 gate — formatting is advisory. (`requires-python` in
-`pyproject.toml` is `>=3.9`.)
+`pyproject.toml` is `>=3.12`.)
 
 ## Configuration & defaults
 

--- a/autogalaxy/plot/plot_utils.py
+++ b/autogalaxy/plot/plot_utils.py
@@ -334,8 +334,8 @@ def _critical_curves_method():
 
     Returns ``"marching_squares"`` (the default) or ``"zero_contour"``.
     Any unrecognised value falls back to ``"marching_squares"`` with a warning.
-    If ``"zero_contour"`` is requested but ``jax_zero_contour`` is not installed
-    (e.g. Python <3.11), falls back to ``"marching_squares"`` with a warning.
+    If ``"zero_contour"`` is requested but ``jax_zero_contour`` is not installed,
+    falls back to ``"marching_squares"`` with a warning.
     """
     from autonerves import conf
 
@@ -357,8 +357,8 @@ def _critical_curves_method():
         except ImportError:
             logger.warning(
                 "critical_curves_method='zero_contour' requested, but "
-                "jax_zero_contour is not installed (Python <3.11 ships without "
-                "the [jax] extra). Falling back to 'marching_squares'."
+                "jax_zero_contour is not installed. Install autogalaxy[jax] "
+                "to use this method. Falling back to 'marching_squares'."
             )
             return "marching_squares"
 

--- a/autogalaxy/util/plot_utils.py
+++ b/autogalaxy/util/plot_utils.py
@@ -334,8 +334,8 @@ def _critical_curves_method():
 
     Returns ``"marching_squares"`` (the default) or ``"zero_contour"``.
     Any unrecognised value falls back to ``"marching_squares"`` with a warning.
-    If ``"zero_contour"`` is requested but ``jax_zero_contour`` is not installed
-    (e.g. Python <3.11), falls back to ``"marching_squares"`` with a warning.
+    If ``"zero_contour"`` is requested but ``jax_zero_contour`` is not installed,
+    falls back to ``"marching_squares"`` with a warning.
     """
     from autonerves import conf
 
@@ -357,8 +357,8 @@ def _critical_curves_method():
         except ImportError:
             logger.warning(
                 "critical_curves_method='zero_contour' requested, but "
-                "jax_zero_contour is not installed (Python <3.11 ships without "
-                "the [jax] extra). Falling back to 'marching_squares'."
+                "jax_zero_contour is not installed. Install autogalaxy[jax] "
+                "to use this method. Falling back to 'marching_squares'."
             )
             return "marching_squares"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description="Open-Source Multi Wavelength Galaxy Structure & Morphology"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 authors = [
     { name = "James Nightingale", email = "James.Nightingale@newcastle.ac.uk" },
     { name = "Richard Hayes", email = "richard@rghsoftware.co.uk" },
@@ -18,9 +18,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]
@@ -53,15 +50,8 @@ jax = [
     # searches (MultiStartAdam / MultiStartProdigy) import. Without it the chain
     # autolens[jax] -> autogalaxy[jax] stopped at autonerves[jax], so `pip
     # install autolens[jax]` left those searches raising ImportError.
-    #
-    # Marked >= 3.11 so this entry matches every other member of the extra.
-    # autofit's own optax entry only gained that marker on main; any *released*
-    # autofit still expands autofit[jax] to an unmarked optax, and resolving
-    # that below 3.11 sends pip backtracking to `resolution-too-deep`. Gating
-    # here makes the chain correct whichever autofit version pip resolves,
-    # rather than only when autofit comes from a source checkout.
-    "autofit[jax]; python_version >= '3.11'",
-    "jax_zero_contour>=2.0.0,<3.0.0; python_version >= '3.11'"
+    "autofit[jax]",
+    "jax_zero_contour>=2.0.0,<3.0.0"
 ]
 optional = [
     "autogalaxy[jax]",


### PR DESCRIPTION
## Summary
Raise PyAutoGalaxy's minimum supported Python version to 3.12 and advertise only Python 3.12 and 3.13.

Remove Python-version markers that became tautological while preserving the supported JAX dependency ranges, and update the missing `jax_zero_contour` guidance for supported runtimes.

Refs #534.

## API Changes
Public Python symbols and signatures are unchanged. Installation now requires Python 3.12 or newer. When the optional zero-contour backend is unavailable, the existing fallback remains and its warning now directs users to install `autogalaxy[jax]` without obsolete pre-3.11 guidance.

## Test Plan
- [x] Python 3.12: 1009 passed
- [x] Python 3.13: 1009 passed
- [x] Package metadata: `Requires-Python: >=3.12`; Python classifiers are 3.12/3.13 only; `autofit[jax]` and `jax_zero_contour>=2.0.0,<3.0.0` are preserved without interpreter markers
- [x] Curated ecosystem smoke accepted with only the known non-causal 300-second `subhalo_recovery.py` timeout
- [x] Independent Claude Opus 5 review: CLEAN
- [x] Heart: YELLOW score 65 within the acknowledged campaign reason set, with no RED reason
- [x] Committed tree is byte-identical to independently reviewed commit `cd8b35da`

## Release Status
No release was performed. This PR is queued with the `pending-release` label, and issue #534 remains open for human-controlled campaign completion.

Generated by the PyAutoLabs agent workflow.
