### PR TITLE
feat: export subplot_fit_imaging_list in autogalaxy.plot

### DIFF
--- a/autogalaxy/plot/__init__.py
+++ b/autogalaxy/plot/__init__.py
@@ -37,6 +37,7 @@ from autogalaxy.galaxy.plot.adapt_plots import (
 
 from autogalaxy.imaging.plot.fit_imaging_plots import (
     subplot_fit as subplot_fit_imaging,
+    subplot_fit_imaging_list,
     subplot_of_galaxy as subplot_fit_imaging_of_galaxy,
 )
 


### PR DESCRIPTION
## Summary
Re-exports `subplot_fit_imaging_list` in `autogalaxy/plot/__init__.py` so workspace examples can plot fits to multiple datasets in one combined subplot via the public `aplt` API — the same function `VisualizerImaging.visualize_combined` uses during multi-dataset model-fits. One-line change; the function itself is unchanged. Needed by autogalaxy_workspace's restructured `scripts/multi/plot.py` (part of PyAutoLabs/autolens_workspace#400).

## API Changes
Adds one public re-export; no behaviour changes, no removals.
See full details below.

## Test Plan
- [x] `pytest test_autogalaxy` (see PR checks)
- [x] `aplt.subplot_fit_imaging_list` import + signature verified from the branch

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autogalaxy.plot.subplot_fit_imaging_list(fit_list, output_path=None, output_filename="fit_combined", output_format=None, title_prefix=None)` — re-export of `autogalaxy.imaging.plot.fit_imaging_plots.subplot_fit_imaging_list`; plots every fit in one subplot, one row per fit.

### Removed
- none

### Migration
- none required

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)