### PR TITLE
docs: replace features overview 'Other' stub with Graphical Models section

### DIFF
--- a/docs/overview/overview_3_features.md
+++ b/docs/overview/overview_3_features.md
@@ -153,7 +153,17 @@ captured using a rectangular mesh:
 Checkout `autogalaxy_workspace/notebooks/features/pixelizations.ipynb` to learn how to use a pixelization, however
 this is a more advanced feature and it is recommended you first get to grips with the core API.
 
-## Other
+## Graphical Models
 
-- Automated pipelines / database tools.
-- Graphical models.
+The examples above fit each galaxy dataset one-by-one. However, many galaxy properties are shared across a
+sample (e.g. the population's distribution of Sersic indices or sizes), and fitting galaxies independently does
+not exploit this shared structure.
+
+Graphical models fit multiple datasets simultaneously, explicitly defining which parameters are unique to each
+galaxy and which are shared across the sample. Hierarchical extensions assume parameters are drawn from a parent
+distribution, whose properties are inferred from the full sample, extracting significantly more information
+than one-by-one fitting. This is a powerful tool for galaxy evolution studies of large samples, for example
+measuring how the galaxy population's structural properties vary with mass or redshift.
+
+Checkout `autofit_workspace/*/features/graphical_models.py` to learn how to compose and fit a graphical model;
+the API applies directly to the galaxy fits shown throughout this workspace.


### PR DESCRIPTION
## Overview

Replaces the `## Other` stub at the end of `docs/overview/overview_3_features.md` — previously two bare bullets — with a full **Graphical Models** feature section in the established format, covering joint sample fits with shared parameters and hierarchical parent distributions, with a pointer to `autofit_workspace/*/features/graphical_models.py`.

The "Automated pipelines / database tools" bullet is dropped per the task request. Companion PRs update the same stub in `autogalaxy_workspace/start_here.py` and the autolens siblings.

Docs-only change (one markdown file, no source touched). Shipped under a human-authorized Heart-RED override — the RED is the unrelated nightly release-validation integrate failure.

Tracked in PyAutoLabs/autolens_workspace#442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
