### PR TITLE
feat: add Python 3.14 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13"
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14"
 ]
 keywords = ["cli"]
 dependencies = [


### PR DESCRIPTION
## Summary
Add the `Programming Language :: Python :: 3.14` trove classifier — Python 3.14 promotion follow-up now the forkserver blocker is fixed and merged (PyAutoLabs/PyAutoFit#1439). Matrix promotion: PyAutoLabs/PyAutoHands#219.

## API Changes
None — packaging metadata only.

## Test Plan
- [x] `pyproject.toml` parses (tomllib); `requires-python >=3.12` unchanged.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)