### PR TITLE
fix: make PointMass and SMBH JAX-compatible

### DIFF
--- a/autogalaxy/profiles/mass/point/point.py
+++ b/autogalaxy/profiles/mass/point/point.py
@@ -50,28 +50,23 @@ class PointMass(MassProfile):
         self.einstein_radius = einstein_radius
 
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        squared_distances = np.square(grid[:, 0] - self.centre[0]) + np.square(
-            grid[:, 1] - self.centre[1]
-        )
-        central_pixel = np.argmin(squared_distances)
-
-        convergence = np.zeros(shape=grid.shape[0])
-        #    convergence[central_pixel] = np.pi * self.einstein_radius ** 2.0
-        return convergence
+        return xp.zeros(grid.shape[0])
 
     @aa.decorators.to_array
     @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        r = xp.sqrt(grid.array[:, 0] ** 2 + grid.array[:, 1] ** 2 + 1e-20)
-        return self.einstein_radius ** 2 * xp.log(r)
+        y = xp.asarray(grid.array[:, 0])
+        x = xp.asarray(grid.array[:, 1])
+        r = xp.sqrt(y**2 + x**2 + 1e-20)
+        return self.einstein_radius**2 * xp.log(r)
 
     @aa.decorators.to_vector_yx
     @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        grid_radii = self.radial_grid_from(grid=grid, xp=xp, **kwargs)
-        return self._cartesian_grid_via_radial_from(
-            grid=grid, radius=self.einstein_radius**2 / grid_radii, xp=xp
-        )
+        y = xp.asarray(grid.array[:, 0])
+        x = xp.asarray(grid.array[:, 1])
+        alpha = self.einstein_radius**2 / (y**2 + x**2 + 1e-20)
+        return xp.stack((alpha * y, alpha * x), axis=-1)
 
     @property
     def is_point_mass(self):

--- a/autogalaxy/profiles/mass/point/smbh.py
+++ b/autogalaxy/profiles/mass/point/smbh.py
@@ -60,7 +60,7 @@ class SMBH(PointMass):
             )
         )
         mass_angular = mass / critical_surface_density
-        einstein_radius = np.sqrt(mass_angular / np.pi)
+        einstein_radius = (mass_angular / np.pi) ** 0.5
 
         super().__init__(centre=centre, einstein_radius=einstein_radius)
 


### PR DESCRIPTION
## Summary
`al.mp.PointMass` and `al.mp.SMBH` failed every JAX-mode fit (user report on 2026.8.4.1; reproduced on main):

- `PointMass.deflections_yx_2d_from` routed through the legacy `radial_grid_from` → `_cartesian_grid_via_radial_from` helpers, which return an `ArrayIrregular` wrapper under `xp=jnp` on the irregular PSF-evaluation grids every imaging fit uses — `jnp.multiply` rejects it (`TypeError: multiply requires ndarray or scalar arguments, got ArrayIrregular`).
- `SMBH.__init__` computed `np.sqrt(mass_angular / np.pi)` — with `mass` a free parameter the instance is built inside the jit trace, so `np.sqrt` receives a tracer (`jax.errors.TracerArrayConversionError`).

Deflections are rewritten with raw `xp` ops (mirroring how `IsothermalSph` already works under JAX), `potential_2d_from` / `convergence_2d_from` are hardened the same way (the convergence central-pixel `argmin` code was dead — its assignment has been commented out for a long time), and the SMBH Einstein radius uses tracer-safe `** 0.5`.

Fixes #553.

## API Changes
None — internal bug fixes only. NumPy-path behaviour is numerically identical (deflections match the previous implementation and the analytic point-mass formula to ~1e-18). The behavioural change is that JAX-mode fits containing `PointMass`/`SMBH` now run instead of raising.
See full details below.

## Test Plan
- [x] `test_autogalaxy/` full suite: 1017 passed
- [x] PyAutoLens `test_autolens/point/`: 115 passed against this branch
- [x] Jitted `AnalysisImaging.log_likelihood_function` with stock `PointMass` (Einstein radius free) and stock `SMBH` (mass free): finite likelihoods — both configurations reproduced the user-reported errors on unfixed main as controls
- [x] `jax.grad` finite for all `PointMass`/`SMBH` parameters (a non-finite `Isothermal.ell_comps` gradient at exactly `(0.0, 0.0)` exists with and without the point mass — pre-existing, unrelated)
- [x] Deflections parity vs analytic `θ_E²/r² · (y, x)`: max abs diff 8.7e-19

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `PointMass.deflections_yx_2d_from` / `potential_2d_from` / `convergence_2d_from` — now tracer-safe under `xp=jnp` (previously raised `TypeError` / `TracerArrayConversionError` in JAX-mode fits); NumPy results numerically unchanged.
- `SMBH.__init__` — Einstein radius computed with tracer-safe `** 0.5` instead of `np.sqrt`; accepts a traced `mass`.

</details>

Generated by the PyAutoLabs agent workflow.
