### PR TITLE
fix: Sph profile inverse transform name-check asymmetry

### DIFF
--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -389,7 +389,7 @@ class EllProfile(SphProfile):
         grid
             The (y, x) coordinates in the reference frame of the profile.
         """
-        if self.__class__.__name__.startswith("Sph"):
+        if self.__class__.__name__.endswith("Sph"):
             return super().transformed_from_reference_frame_grid_from(grid=grid, xp=xp)
 
         return aa.util.geometry.transform_grid_2d_from_reference_frame(

--- a/test_autogalaxy/profiles/test_geometry_profiles.py
+++ b/test_autogalaxy/profiles/test_geometry_profiles.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -133,6 +134,36 @@ def test__spherical__transform_to_and_from_reference_frame__roundtrip_recovers_o
     )
 
     assert transformed_grid == pytest.approx(grid_original, 1e-5)
+
+
+def test__sph_named_profile__both_transforms_use_translation_only_path():
+    # Regression test: transformed_from_reference_frame_grid_from checked
+    # startswith("Sph") but spherical profiles are suffix-named (IsothermalSph),
+    # so the inverse transform silently took the elliptical rotation path.
+    profile = ag.mp.IsothermalSph(centre=(1.0, 2.0), einstein_radius=1.0)
+
+    grid = ag.Grid2DIrregular([[3.0, 5.0]])
+
+    transformed_grid = profile.transformed_to_reference_frame_grid_from(grid)
+
+    assert transformed_grid == pytest.approx(np.array([[2.0, 3.0]]), 1e-8)
+
+    recovered_grid = profile.transformed_from_reference_frame_grid_from(
+        transformed_grid
+    )
+
+    assert recovered_grid == pytest.approx(grid.array, 1e-8)
+
+    with mock.patch.object(
+        geometry_profiles.aa.util.geometry, "transform_grid_2d_to_reference_frame"
+    ) as rotation_to, mock.patch.object(
+        geometry_profiles.aa.util.geometry, "transform_grid_2d_from_reference_frame"
+    ) as rotation_from:
+        profile.transformed_to_reference_frame_grid_from(grid)
+        profile.transformed_from_reference_frame_grid_from(transformed_grid)
+
+    rotation_to.assert_not_called()
+    rotation_from.assert_not_called()
 
 
 def test__elliptical__transform_grid_to_reference_frame__zero_ell_comps__grid_unchanged():


### PR DESCRIPTION
## Summary
`EllProfile.transformed_from_reference_frame_grid_from` checked `self.__class__.__name__.startswith("Sph")` while its mirror `transformed_to_reference_frame_grid_from` checks `endswith("Sph")`. Spherical profiles are suffix-named (`IsothermalSph`, `NFWSph`, ...) and no concrete class starts with "Sph", so the inverse transform's spherical branch never fired — every spherical profile took the elliptical rotation path. Numerically benign today (spherical profiles have `angle = 0`, an exact identity rotation), but the transforms were asymmetric and the inverse did wasted rotation work on the hot path. Fixed to `endswith("Sph")`; a stack-wide sweep (PyAutoGalaxy/PyAutoLens/PyAutoArray/PyAutoFit) confirms this was the only occurrence of the pattern.

Known residual: `IsothermalSphMLR` (name ends "MLR") is missed by both name checks and continues down the elliptical path — numerically correct, flagged here rather than inventing a new dispatch mechanism for one class.

Closes #555.

## API Changes
None — internal changes only.

## Test Plan
- [x] New regression test `test__sph_named_profile__both_transforms_use_translation_only_path` asserts (via mock) that neither transform calls the rotation helper for a suffix-named spherical profile. Control-verified: fails on the unfixed source, passes with the fix.
- [x] `test_autogalaxy/profiles`: 619 passed.
- [x] Full `test_autogalaxy` suite run at ship time (counts in PR checks / ship log).

<details>
<summary>Full API Changes (for automation & release notes)</summary>

None — internal changes only. No public symbols added, removed, renamed, or changed in signature; numerical results unchanged (the previously-taken elliptical path applied an exact identity rotation).

</details>

## Ship gate note
Shipped with explicit human authorization under Heart RED — reason `release validation FAILED (stage integrate)`, an unrelated in-flight release-validation run; this change was uncommitted at the time of that verdict. Merge remains a separate human decision.

Generated by the PyAutoLabs agent workflow.