### PR TITLE
fix: drop stale astropy cap + stale cosmology docstrings

### DIFF
--- a/autogalaxy/cosmology/model.py
+++ b/autogalaxy/cosmology/model.py
@@ -123,7 +123,7 @@ class LensingCosmology:
         Weinberg, 1972, pp 421-424; Weedman, 1986, pp 65-67; Peebles, 1993, pp 325-327.
 
         For simplicity, **PyAutoLens** internally uses only certain units to perform lensing cosmology calculations.
-        This function therefore returns only the value of the astropy function it wraps, omitting the units instance.
+        This function therefore returns a plain value in kpc, with no units instance attached.
 
         Parameters
         ----------
@@ -139,7 +139,7 @@ class LensingCosmology:
         Angular diameter distance from an input `redshift_0` to another input `redshift_1`.
 
         For simplicity, **PyAutoLens** internally uses only certain units to perform lensing cosmology calculations.
-        This function therefore returns only the value of the astropy function it wraps, omitting the units instance.
+        This function therefore returns a plain value in kpc, with no units instance attached.
 
         Parameters
         ----------
@@ -212,13 +212,9 @@ class LensingCosmology:
         """
         Critical density of the Universe at redshift z, returned in Msun / kpc^3.
 
-        This is an xp (NumPy / JAX) drop-in for the Astropy method:
-            astropy.cosmology.FLRW.critical_density(z)
-
-        Astropy returns g/cm^3, but in AutoLens you were immediately converting to:
-            solMass / kpc^3
-
-        So this function returns Msun / kpc^3 directly.
+        A native xp (NumPy / JAX) implementation whose value matches the astropy method
+        astropy.cosmology.FLRW.critical_density(z) after converting its g / cm^3 result
+        to Msun / kpc^3 — the units lensing calculations use directly.
 
         Requires:
             self.H0  (km/s/Mpc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # PyAutoLens#687.
     "autofit>=2026.7.29.2",
     "autoarray>=2026.7.29.2",
-    "astropy>=5.0,<=7.2.0",
+    "astropy>=5.0",
     "nautilus-sampler==1.0.5"
 ]
 


### PR DESCRIPTION
## Summary
Sibling of the PyAutoArray astropy-floor PR: drop the stale `<=7.2.0` astropy cap, keeping `astropy>=5.0` (floors, not pins). Also corrects three stale docstrings in `autogalaxy/cosmology/model.py`: the cosmology is a native xp (NumPy/JAX) implementation, but two methods still claimed to "return only the value of the astropy function it wraps", and `critical_density` carried a conversational porting note. The accurate astropy parity statements (value-matching `astropy.cosmology`) are deliberately kept — they document a real compatibility contract.

Part of PyAutoLabs/PyAutoArray#434.

## API Changes
None — internal changes only.

## Test Plan
- [x] `pytest test_autogalaxy/` — 1027 passed under astropy 8.0.1
- [x] Clean-venv `pip install --dry-run` on the sibling PyAutoArray change: resolves astropy 8.0.1 (control on capped main: 7.2.0)
- [x] FITS-loaded imaging fit smoke (`ag.Imaging.from_fits` + `ag.FitImaging`) under astropy 8.0.1

<details>
<summary>Full API Changes (for automation & release notes)</summary>

None — dependency-metadata change (`pyproject.toml` astropy specifier `>=5.0,<=7.2.0` → `>=5.0`) plus docstring-only edits in `autogalaxy/cosmology/model.py` (no signature or behaviour changes).

</details>

Generated by the PyAutoLabs agent workflow.