### PR TITLE
Expose DelaunayNN mesh

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -44,6 +44,9 @@ from autoarray.inversion.mesh.interpolator.rectangular import (
 from autoarray.inversion.mesh.interpolator.delaunay import (
     InterpolatorDelaunay,
 )  # noqa
+from autoarray.inversion.mesh.interpolator.sibson import (
+    InterpolatorDelaunayNN,
+)  # noqa
 from autoarray.structures.vectors.uniform import VectorYX2D  # noqa
 from autoarray.structures.vectors.irregular import VectorYX2DIrregular  # noqa
 from autoarray.layout.region import Region1D  # noqa

--- a/autogalaxy/config/priors/mesh/delaunay.yaml
+++ b/autogalaxy/config/priors/mesh/delaunay.yaml
@@ -1,1 +1,2 @@
 Delaunay:
+DelaunayNN:


### PR DESCRIPTION
## Summary

- expose `DelaunayNN` through the PyAutoGalaxy public namespace
- add the mesh prior configuration needed by model composition

## Dependency

Companion to the core implementation in https://github.com/PyAutoLabs/PyAutoArray/pull/441.

## Validation

- import smoke coverage passed through the workspace checks
- `git diff --check` passes