### PR TITLE
fix: let MockResult accept and forward samples_summary

### DIFF
--- a/autogalaxy/analysis/mock/mock_result.py
+++ b/autogalaxy/analysis/mock/mock_result.py
@@ -12,6 +12,7 @@ class MockResult(af.m.MockResult):
     def __init__(
         self,
         samples: mock.MockSamples = None,
+        samples_summary: af.m.MockSamplesSummary = None,
         instance: af.Instance = None,
         model: af.Model = None,
         analysis: mock.MockAnalysis = None,
@@ -21,6 +22,7 @@ class MockResult(af.m.MockResult):
     ):
         super().__init__(
             samples=samples,
+            samples_summary=samples_summary,
             instance=instance,
             model=model,
             analysis=analysis,


### PR DESCRIPTION
## Problem

`ag.m.MockResult` subclasses `af.m.MockResult` but omits `samples_summary` from its signature, so it is never forwarded to `super()`:

```python
ag.m.MockResult(model=model, samples=samples, samples_summary=samples.summary())
TypeError: MockResult.__init__() got an unexpected keyword argument 'samples_summary'
```

Callers therefore could not supply a summary at all through this subclass, and were silently forced onto the parent's placeholder summary. That placeholder filled every parameter with `1.0`, which is an invalid `ell_comps` — the failure fixed in PyAutoFit#1471.

## Change

Add `samples_summary` to the signature and forward it to `super().__init__`. One line each way; no behaviour change for existing callers, which pass `None` by omission exactly as before.

`al.m.MockResult` **is** this class (re-exported by PyAutoLens, not a second subclass), so PyAutoLens is covered by the same change — no separate fix needed there.

## Tests

| Suite | Result |
|---|---|
| `test_autogalaxy` | 1081 passed, 0 failed |
| `test_autolens` | 518 passed, 1 failed (pre-existing, unrelated) |
| 7 aggregator integration scripts | 7/7 pass |

The pre-existing PyAutoLens failure is `potential_correction/test_iterative_interferometer.py::test__solve_joint_optimization__identity_damping_finite`; it reproduces without this change.

## Related

Depends on PyAutoFit#1471 for the placeholder-value fix itself. Merge that one first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqpBSWF2JDx4L9g1YCQk67)_