### PR TITLE
fix: make circular ell_comps image gradients finite

### DIFF
--- a/autogalaxy/profiles/light/standard/sersic.py
+++ b/autogalaxy/profiles/light/standard/sersic.py
@@ -166,10 +166,46 @@ class Sersic(AbstractSersic, LightProfile):
             ),
         )
 
+    @aa.decorators.to_array
+    def _eccentric_radii_grid_from_cartesian(
+        self, grid: aa.type.Grid2DLike, xp=np, **kwargs
+    ) -> np.ndarray:
+        """Return eccentric radii without converting ``ell_comps`` to polar form."""
+        ell_comps_y, ell_comps_x = self.ell_comps
+        ell_comps_norm = xp.sqrt(
+            xp.maximum(
+                xp.add(xp.square(ell_comps_y), xp.square(ell_comps_x)),
+                1.0e-12,
+            )
+        )
+        ell_comps_scale = xp.minimum(1.0, 0.999 / ell_comps_norm)
+
+        ell_comps_y = xp.multiply(ell_comps_y, ell_comps_scale)
+        ell_comps_x = xp.multiply(ell_comps_x, ell_comps_scale)
+        ell_comps_norm_squared = xp.add(xp.square(ell_comps_y), xp.square(ell_comps_x))
+
+        y = xp.add(grid.array[:, 0], -self.centre[0])
+        x = xp.add(grid.array[:, 1], -self.centre[1])
+
+        numerator = xp.add(
+            xp.multiply(
+                xp.add(1.0 + ell_comps_norm_squared, -2.0 * ell_comps_x),
+                xp.square(x),
+            ),
+            xp.add(
+                xp.multiply(-4.0 * ell_comps_y, xp.multiply(x, y)),
+                xp.multiply(
+                    xp.add(1.0 + ell_comps_norm_squared, 2.0 * ell_comps_x),
+                    xp.square(y),
+                ),
+            ),
+        )
+
+        return xp.sqrt(xp.divide(numerator, 1.0 - ell_comps_norm_squared))
+
     @aa.over_sample
     @aa.decorators.to_array
     @check_operated_only
-    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,
@@ -194,7 +230,12 @@ class Sersic(AbstractSersic, LightProfile):
             The image of the Sersic evaluated at every (y,x) coordinate on the transformed grid.
         """
 
-        grid_radii = self.eccentric_radii_grid_from(grid=grid, xp=xp, **kwargs)
+        if getattr(grid, "is_transformed", False):
+            grid_radii = self.eccentric_radii_grid_from(grid=grid, xp=xp, **kwargs)
+        else:
+            grid_radii = self._eccentric_radii_grid_from_cartesian(
+                grid=grid, xp=xp, **kwargs
+            )
 
         return self.image_2d_via_radii_from(grid_radii=grid_radii, xp=xp, **kwargs)
 

--- a/test_autogalaxy/profiles/light/standard/test_sersic.py
+++ b/test_autogalaxy/profiles/light/standard/test_sersic.py
@@ -60,6 +60,7 @@ def test__image_2d_from__spherical_profile__matches_elliptical_with_zero_ellipti
 
     assert image_elliptical.array == pytest.approx(image_spherical.array, 1.0e-4)
 
+
 @pytest.mark.parametrize(
     "ell_comps",
     [(0.0, 0.0), (0.18, 0.22), (-0.31, 0.14), (0.0, 0.9995)],

--- a/test_autogalaxy/profiles/light/standard/test_sersic.py
+++ b/test_autogalaxy/profiles/light/standard/test_sersic.py
@@ -59,3 +59,32 @@ def test__image_2d_from__spherical_profile__matches_elliptical_with_zero_ellipti
     image_spherical = spherical.image_2d_from(grid=grid)
 
     assert image_elliptical.array == pytest.approx(image_spherical.array, 1.0e-4)
+
+@pytest.mark.parametrize(
+    "ell_comps",
+    [(0.0, 0.0), (0.18, 0.22), (-0.31, 0.14), (0.0, 0.9995)],
+)
+def test__image_2d_from__cartesian_radii_match_transformed_reference_frame(
+    ell_comps,
+):
+    profile = ag.lp.Sersic(
+        centre=(0.07, -0.11),
+        ell_comps=ell_comps,
+        intensity=1.3,
+        effective_radius=0.8,
+        sersic_index=2.2,
+    )
+    grid = ag.Grid2DIrregular(
+        [[0.13, -0.22], [0.51, 0.37], [-0.42, 0.81], [1.2, -0.63]]
+    )
+
+    transformed_grid = profile.transformed_to_reference_frame_grid_from(grid=grid)
+    transformed_grid.is_transformed = True
+
+    image = profile.image_2d_from(grid=grid)
+    image_via_transformed_grid = profile.image_2d_from(grid=transformed_grid)
+
+    assert image.array == pytest.approx(
+        image_via_transformed_grid.array, rel=2.0e-12, abs=2.0e-12
+    )
+


### PR DESCRIPTION
## Summary

- evaluate Sersic eccentric radii directly from Cartesian `ell_comps`, avoiding the undefined polar angle derivative at `(0, 0)`
- preserve the existing `fac <= 0.999` clamp and transformed-grid compatibility
- add NumPy parity coverage for circular, anisotropic, rotated, and near-clamped profiles

Closes #570.

## Why

The profiling hazard `likelihood.imaging-sersic.ell-comps-origin-nonfinite-gradient` showed a finite off-centre Sersic image and complete `FitImaging` likelihood at the circular point, but a `[NaN, NaN]` JAX gradient. The sampled parameters are Cartesian `ell_comps_0/1`; converting them to axis ratio and angle introduces an avoidable polar singularity.

The new radius identity remains in Cartesian coordinates:

```
r_ecc^2 =
  ((1 + f^2 - 2 e_x) x^2 - 4 e_y x y + (1 + f^2 + 2 e_x) y^2)
  / (1 - f^2)
```

where `f^2=e_y^2+e_x^2` after the existing magnitude clamp.

## Validation

- focused current Sersic tests: **8 passed**
- NumPy direct/legacy image parity: maximum absolute difference `1.46e-15` across circular, anisotropic, rotated, and near-clamped cases
- downstream JAX `jit(grad)` image probe at `ell_comps=(0, 0)`: finite; central differences at `1e-4`, `1e-5`, and `1e-6` agree
- downstream full `FitImaging` likelihood: value unchanged at `-15.477240141252718`; origin gradient now finite at `[1.1569945714414, -0.5449763942867472]`; all ±`1e-8` and ±`1e-6` neighbourhood gradients finite
- formatting check and compile check passed
- JAX validation is downstream rather than in PyAutoGalaxy unit tests, per repository policy

No public API, prior, configuration, or release change.