### PR TITLE
chore: sync __version__ stamp to 2026.8.17.1 (freeze documented)

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -131,7 +131,10 @@ from autonerves.fitsable import header_obj_from
 from autonerves.fitsable import output_to_fits
 from autonerves.fitsable import hdu_list_for_output_from
 
-__version__ = "2026.7.23.1"
+# Last manual sync of the source stamp. Release wheels are stamped at build
+# time and the git tag is the release truth — deliberately never bumped per
+# release (PyAutoBuild#118/#120).
+__version__ = "2026.8.17.1"
 
 from autonerves import check_version
 


### PR DESCRIPTION
## Summary
Deliberate manual sync of the frozen source `__version__` stamp from `2026.7.23.1` to the latest release `2026.8.17.1`, with a comment documenting the freeze design: release wheels are stamped at build time, the git tag is the release truth, and the source literal is deliberately never bumped per release (PyAutoBuild#118/#120 — per-release bump commits were the noise engine behind the June/July 2026 accidental-release cascade).

Part of PyAutoLabs/PyAutoHands#235 (six sibling PRs: five stamp syncs + release-sed guards).

## API Changes
None — internal changes only. The `__version__` value syncs to what released wheels already report.

Behavioral note: at `2026.8.17.1` the stamp is >30 days past the current workspace floors (`2026.7.9.1`), so source checkouts running workspace scripts now see the same `check_version` staleness warning that pip users on the `2026.8.17.1` wheel already see today (CI sets `PYAUTO_SKIP_WORKSPACE_VERSION_CHECK=1`; devs can too, or the workspace floors can be bumped when scripts next require newer API).
See full details below.

## Test Plan
- [x] `ast.parse` passes on the edited `__init__.py`
- [x] Release stamp sed simulated against the new file: stamps cleanly; the new guard (PyAutoHands PR) catches corruption
- [ ] Full library test suite at ship time

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autogalaxy.__version__` — literal synced `2026.7.23.1` → `2026.8.17.1` (matches released wheels; no signature or symbol changes)

</details>

Generated by the PyAutoLabs agent workflow.
