### PR TITLE
refactor: future-annotations headers for lazy af.Aggregator

### DIFF
--- a/autogalaxy/aggregator/imaging/imaging.py
+++ b/autogalaxy/aggregator/imaging/imaging.py
@@ -13,6 +13,8 @@ Two public objects are provided:
 - ``ImagingAgg`` — a class wrapping an ``Aggregator`` that returns a lazy generator of
   ``Imaging`` datasets, avoiding loading all results into memory at once.
 """
+
+from __future__ import annotations
 from functools import partial
 from typing import List
 

--- a/autogalaxy/aggregator/interferometer/interferometer.py
+++ b/autogalaxy/aggregator/interferometer/interferometer.py
@@ -15,6 +15,8 @@ Two public objects are provided:
   generator of ``Interferometer`` datasets, avoiding loading all results into memory at
   once.
 """
+
+from __future__ import annotations
 from functools import partial
 from typing import List
 


### PR DESCRIPTION
## Summary
Part of the cross-repo import-time task (PyAutoFit#1505). PyAutoFit's `Aggregator` is now a lazy attribute so sqlalchemy + the database models stay off the bare import path — but two aggregator modules here evaluate `af.Aggregator` in def-time annotations, re-triggering that import. Two one-line `from __future__ import annotations` headers (imaging.py, interferometer.py; the other aggregator modules already have them) make the annotations lazy strings.

## API Changes
None — internal changes only (annotation evaluation semantics in two modules).
See full details below.

## Test Plan
- [x] Full suite: 1111 passed against the PyAutoFit/PyAutoArray/PyAutoNerves branches
- [x] `import autolens` shows no sqlalchemy in the import tree
- [x] autogalaxy_workspace smoke: 16/16 passed

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- None — `from __future__ import annotations` added to `aggregator/imaging/imaging.py` and `aggregator/interferometer/interferometer.py`; annotations become lazy strings (PEP 563), no runtime introspection of them exists.

### Migration
- None required.

</details>

Generated by the PyAutoLabs agent workflow.
