### PR TITLE
Return no operated_mapping_matrix_override when psf is None

### DIFF
--- a/autogalaxy/profiles/light/linear/abstract.py
+++ b/autogalaxy/profiles/light/linear/abstract.py
@@ -336,6 +336,13 @@ class LightProfileLinearObjFuncList(aa.AbstractLinearObjFuncList):
         performed in the linear equation solvers.
         """
 
+        if self.psf is None:
+            # Interferometer fits construct this object with `psf=None`: the override below is
+            # image-space and PSF-based, whereas an interferometer override must be in visibility
+            # space, so `None` keeps the standard mapping_matrix -> transformer inversion path
+            # (which is correct for both ordinary and operated light profiles).
+            return None
+
         if isinstance(self.light_profile_list[0], LightProfileOperated):
             return self.mapping_matrix
 

--- a/test_autogalaxy/profiles/light/linear/test_abstract.py
+++ b/test_autogalaxy/profiles/light/linear/test_abstract.py
@@ -79,6 +79,28 @@ def test__operated_mapping_matrix__columns_match_individual_blurred_images(
     ] == pytest.approx(lp_1_blurred_image.array, 1.0e-4)
 
 
+def test__operated_mapping_matrix_override__psf_none_returns_none(
+    grid_2d_7x7, blurring_grid_2d_7x7
+):
+    lp_linear_obj_func_list = LightProfileLinearObjFuncList(
+        grid=grid_2d_7x7,
+        blurring_grid=blurring_grid_2d_7x7,
+        psf=None,
+        light_profile_list=[ag.lp_linear.Sersic(effective_radius=1.0)],
+    )
+
+    assert lp_linear_obj_func_list.operated_mapping_matrix_override is None
+
+    lp_linear_obj_func_list_operated = LightProfileLinearObjFuncList(
+        grid=grid_2d_7x7,
+        blurring_grid=blurring_grid_2d_7x7,
+        psf=None,
+        light_profile_list=[ag.lp_linear_operated.Gaussian()],
+    )
+
+    assert lp_linear_obj_func_list_operated.operated_mapping_matrix_override is None
+
+
 def test__lp_instance_from__returns_non_linear_instance_with_correct_type_and_centre():
     lp_linear = ag.lp_linear.Sersic(centre=(1.0, 2.0))
 


### PR DESCRIPTION
Companion to PyAutoLabs/PyAutoArray#460 (PyAutoLabs/PyAutoArray#459).

PyAutoArray interferometer inversions now read `operated_mapping_matrix_override`. Interferometer fits construct `LightProfileLinearObjFuncList` with `psf=None`, where the image-space PSF-based override does not apply — and evaluating it would crash on `psf.convolve_over_sample_size`.

## Changes

- `profiles/light/linear/abstract.py` — `operated_mapping_matrix_override` returns `None` when `self.psf is None`, keeping the standard `mapping_matrix` → transformer path for both ordinary and operated linear light profiles. Existing interferometer behaviour is preserved exactly.
- Test covering both the ordinary (`lp_linear.Sersic`) and operated (`lp_linear_operated.Gaussian`) cases with `psf=None`.

**Merge together with PyAutoLabs/PyAutoArray#460** — this guard must land no later than the autoarray change.

## Test results

`test_autogalaxy/`: 1112 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lv2LDovvSQydk8biNMSAPL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv2LDovvSQydk8biNMSAPL)_