### PR TITLE
feat: rectangular mesh split follow-up — RTU/Bilinear prior configs + docs

### DIFF
--- a/autogalaxy/config/priors/mesh/rectangular_bilinear_adapt_density.yaml
+++ b/autogalaxy/config/priors/mesh/rectangular_bilinear_adapt_density.yaml
@@ -1,0 +1,21 @@
+RectangularBilinearAdaptDensity:
+  shape_0:
+    type: Uniform
+    lower_limit: 20.0
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+    limits:
+      lower: 3.0
+      upper: inf
+  shape_1:
+    type: Uniform
+    lower_limit: 20.0
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+    limits:
+      lower: 3.0
+      upper: inf

--- a/autogalaxy/config/priors/mesh/rectangular_bilinear_adapt_image.yaml
+++ b/autogalaxy/config/priors/mesh/rectangular_bilinear_adapt_image.yaml
@@ -1,0 +1,40 @@
+RectangularBilinearAdaptImage:
+  shape_0:
+    type: Uniform
+    lower_limit: 20.0
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+    limits:
+      lower: 3.0
+      upper: inf
+  shape_1:
+    type: Uniform
+    lower_limit: 20.0
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+    limits:
+      lower: 3.0
+      upper: inf
+  weight_power:
+    type : Uniform
+    lower_limit: 0.0
+    upper_limit: 10.0
+    width_modifier:
+      type: Absolute
+      value: 2.0
+    limits:
+      lower: -100.0
+      upper: 100.0
+  weight_floor:
+    type: LogUniform
+    lower_limit: 0.00001
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+    limits:
+      lower: 0.0
+      upper: inf

--- a/autogalaxy/config/priors/mesh/rectangular_rtu_adapt_density.yaml
+++ b/autogalaxy/config/priors/mesh/rectangular_rtu_adapt_density.yaml
@@ -1,4 +1,4 @@
-RectangularAdaptDensity:
+RectangularRTUAdaptDensity:
   shape_0:
     type: Uniform
     lower_limit: 20.0

--- a/autogalaxy/config/priors/mesh/rectangular_rtu_adapt_image.yaml
+++ b/autogalaxy/config/priors/mesh/rectangular_rtu_adapt_image.yaml
@@ -1,4 +1,4 @@
-RectangularAdaptImage:
+RectangularRTUAdaptImage:
   shape_0:
     type: Uniform
     lower_limit: 20.0

--- a/autogalaxy/exc.py
+++ b/autogalaxy/exc.py
@@ -51,7 +51,7 @@ class PixelizationException(af.exc.FitException):
     """
     Raises exceptions associated with the `inversion/pixelization` modules and `Pixelization` classes.
 
-    For example if a `RectangularAdaptDensity` mesh has dimensions below 3x3.
+    For example if a `RectangularRTUAdaptDensity` mesh has dimensions below 3x3.
 
     This exception overwrites `autoarray.exc.PixelizationException` in order to add a `FitException`. This means that
     if this exception is raised during a model-fit in the analysis class's `log_likelihood_function` that model

--- a/docs/api/pixelization.rst
+++ b/docs/api/pixelization.rst
@@ -49,7 +49,10 @@ Mesh [ag.mesh]
    :template: custom-class-template.rst
    :recursive:
 
-   RectangularAdaptDensity
+   RectangularBilinearAdaptDensity
+   RectangularBilinearAdaptImage
+   RectangularRTUAdaptDensity
+   RectangularRTUAdaptImage
    Delaunay
 
 Regularization [ag.reg]

--- a/test_autogalaxy/profiles/config/summary/priors/pixelizations.json
+++ b/test_autogalaxy/profiles/config/summary/priors/pixelizations.json
@@ -1,5 +1,12 @@
 {
-    "rectangular.RectangularAdaptDensity": {
+    "Voronoi": {
+        "pixels": {
+            "type": "Uniform",
+            "lower_limit": 0.0,
+            "upper_limit": 1.0
+        }
+    },
+    "rectangular_bilinear_adapt_density.RectangularBilinearAdaptDensity": {
         "shape_0": {
             "type": "Uniform",
             "lower_limit": 10.0,
@@ -11,11 +18,16 @@
             "upper_limit": 30.0
         }
     },
-    "Voronoi": {
-        "pixels": {
+    "rectangular_rtu_adapt_density.RectangularRTUAdaptDensity": {
+        "shape_0": {
             "type": "Uniform",
-            "lower_limit": 0.0,
-            "upper_limit": 1.0
+            "lower_limit": 10.0,
+            "upper_limit": 30.0
+        },
+        "shape_1": {
+            "type": "Uniform",
+            "lower_limit": 10.0,
+            "upper_limit": 30.0
         }
     }
 }

--- a/test_autogalaxy/profiles/mass/config/summary/priors/pixelizations.json
+++ b/test_autogalaxy/profiles/mass/config/summary/priors/pixelizations.json
@@ -1,5 +1,12 @@
 {
-    "rectangular.RectangularAdaptDensity": {
+    "Voronoi": {
+        "pixels": {
+            "type": "Uniform",
+            "lower_limit": 0.0,
+            "upper_limit": 1.0
+        }
+    },
+    "rectangular_bilinear_adapt_density.RectangularBilinearAdaptDensity": {
         "shape_0": {
             "type": "Uniform",
             "lower_limit": 10.0,
@@ -11,11 +18,16 @@
             "upper_limit": 30.0
         }
     },
-    "Voronoi": {
-        "pixels": {
+    "rectangular_rtu_adapt_density.RectangularRTUAdaptDensity": {
+        "shape_0": {
             "type": "Uniform",
-            "lower_limit": 0.0,
-            "upper_limit": 1.0
+            "lower_limit": 10.0,
+            "upper_limit": 30.0
+        },
+        "shape_1": {
+            "type": "Uniform",
+            "lower_limit": 10.0,
+            "upper_limit": 30.0
         }
     }
 }


### PR DESCRIPTION
## Summary

Downstream follow-up to the PyAutoArray rectangular mesh split (PyAutoLabs/PyAutoArray#462, merged; task PyAutoLabs/PyAutoArray#461). PyAutoGalaxy ships packaged prior-config defaults keyed by the renamed classes, so without this the new class names have no library-side default priors.

## API Changes

None — internal changes only (packaged config defaults, docs, docstrings; no Python API change).

## Test Plan

- [x] Full test suite against merged PyAutoArray main: 1102 passed, 1 skipped.
- [x] Prior-config key resolution verified empirically: the old `rectangular.<Class>` module-prefixed keys in the test `pixelizations.json` configs never resolved (autonerves `JSONPriorConfig` matches on the real module path via `endswith`); they are rekeyed to `rectangular_bilinear_adapt_density.RectangularBilinearAdaptDensity` / `rectangular_rtu_adapt_density.RectangularRTUAdaptDensity`, which do resolve.

<details>
<summary>Changes</summary>

- `autogalaxy/config/priors/mesh/`: `rectangular_adapt_density.yaml` → `rectangular_rtu_adapt_density.yaml`, `rectangular_adapt_image.yaml` → `rectangular_rtu_adapt_image.yaml` (top-level keys renamed to the RTU class names); new `rectangular_bilinear_adapt_density.yaml` / `rectangular_bilinear_adapt_image.yaml` with the same priors (the Bilinear meshes have no `bandwidth`/`n_knots`).
- `docs/api/pixelization.rst`: lists all four adaptive rectangular classes.
- `autogalaxy/exc.py`: docstring name update.
- `test_autogalaxy/profiles/{config,mass/config}/summary/priors/pixelizations.json`: stale key fix (above).

</details>

Generated by the PyAutoLabs agent workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtMqU3JfmyJh8GvB7jT4Et)_