### PR TITLE
fix: Basis linear-profile placeholder on irregular grids

### DIFF
--- a/autogalaxy/profiles/basis.py
+++ b/autogalaxy/profiles/basis.py
@@ -159,9 +159,13 @@ class Basis(LightProfile, MassProfile):
                 )
             elif kwargs.get("binned", True) is False:
                 image_2d_list.append(xp.zeros((grid.over_sampled.shape[0],)))
-            else:
+            elif isinstance(grid, aa.Grid2D):
                 image_2d_list.append(
                     aa.Array2D(values=xp.zeros((grid.shape[0],)), mask=grid.mask)
+                )
+            else:
+                image_2d_list.append(
+                    aa.ArrayIrregular(values=xp.zeros((grid.shape[0],)))
                 )
 
         return image_2d_list

--- a/test_autogalaxy/profiles/test_basis.py
+++ b/test_autogalaxy/profiles/test_basis.py
@@ -61,6 +61,25 @@ def test__image_2d_from__returns_array2d_for_linear_only_basis(grid_2d_7x7):
     assert isinstance(image, aa.Array2D)
 
 
+def test__image_2d_from__grid_2d_irregular__linear_profile_placeholder_has_no_mask():
+    # Regression test: the linear-intensity-unknown placeholder used to be built as
+    # `Array2D(..., mask=grid.mask)`, which raised `AttributeError: Grid2DIrregular
+    # does not have attribute mask` whenever a basis containing a linear light
+    # profile was evaluated on an irregular grid (as JIT-traced likelihood paths do).
+    grid = aa.Grid2DIrregular(values=[(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)])
+
+    lp = ag.lp.Sersic(intensity=0.1)
+    lp_linear = ag.lp_linear.Sersic(effective_radius=2.0, sersic_index=2.0)
+
+    basis = ag.lp_basis.Basis(profile_list=[lp, lp_linear])
+
+    image = basis.image_2d_from(grid=grid)
+
+    assert isinstance(image, aa.ArrayIrregular)
+    assert image.shape == (3,)
+    assert image == pytest.approx(np.asarray(lp.image_2d_from(grid=grid)), 1.0e-8)
+
+
 def test__image_2d_from__operated_only_false__returns_only_non_operated_profile_image(
     grid_2d_7x7, lp_0, lp_operated_0
 ):


### PR DESCRIPTION
Fixes the `Basis` library bug found while unblocking
`autolens_workspace_developer/jax_profiling/jit/imaging/pixelization.py`
(PyAutoGalaxy#580).

## The bug

`Basis.image_2d_list_from` builds the zero placeholder for its
`LightProfileLinear` members as:

```python
aa.Array2D(values=xp.zeros((grid.shape[0],)), mask=grid.mask)
```

which assumes a masked `Grid2D`. Evaluating a basis that contains a linear light
profile on a `Grid2DIrregular` therefore raises:

```
AttributeError: Grid2DIrregular does not have attribute mask
```

`Grid2DIrregular` is the grid type JIT-traced likelihood paths use, so any such
path with a linear-light basis — an MGE lens light, for instance — was simply
unreachable.

## The fix

Dispatch on grid type: `ArrayIrregular` for irregular grids, `Array2D` for
`Grid2D`. This mirrors how `ArrayMaker.via_grid_2d` / `via_grid_2d_irr`
(`PyAutoArray/autoarray/structures/decorators/to_array.py`) already choose the
return type for the *non-linear* profiles in the same list, so the placeholder
now matches its siblings instead of contradicting them.

## Testing

- New regression test in `test_autogalaxy/profiles/test_basis.py`: a `Basis` of
  one `Sersic` + one `lp_linear.Sersic` on a `Grid2DIrregular` returns an
  `ArrayIrregular` equal to the non-linear profile's image, instead of raising.
- Full `test_autogalaxy` suite: **1113 passed**.
- End-to-end: with this fix the pixelization profiling script runs to completion
  and its rebuilt log-evidence matches `FitImaging.figure_of_merit` to 13
  significant figures.

Workspace follow-up (the script itself) is
autolens_workspace_developer `feature/pixelization-eager-jit-divergence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdsQ7c6y3iuiQf2jy8gx6K
