### PR TITLE
build: bump intra-family floors to >=2026.8.22.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
     # Floors, not pins (PyAutoLens#687) — bump to the first release with JAX
     # in the family's base dependencies once it exists (PyAutoLens#702), so
     # backtracking cannot pair this autogalaxy with a jax-optional chain.
-    "autofit>=2026.7.29.2",
-    "autoarray>=2026.7.29.2",
+    "autofit>=2026.8.22.1",
+    "autoarray>=2026.8.22.1",
     "astropy>=5.0",
     "nautilus-sampler==1.0.5",
     # Marker-gated like the jax deps in autonerves (jax_zero_contour depends


### PR DESCRIPTION
Release `2026.8.22.1` promoted all five libraries together (nightly run 50), so the committed source floors move from the previous promoted set `2026.7.29.2` to the first version carrying the JAX-default dependency handshake, the fnnls JAX fix (PyAutoArray#463) and the rectangular mesh split. Step (1) of the `jax-default-dependency` follow-ups recorded in PyAutoMind `active.md`; sibling PRs bump PyAutoFit, PyAutoArray and PyAutoLens.

Two lines: `autofit`/`autoarray` `>=2026.7.29.2` → `>=2026.8.22.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7

---
_Generated by [Claude Code](https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7)_