### PR TITLE
refactor: delegate norm_from to the shared autoarray helper

### DIFF
--- a/autogalaxy/util/plot_utils.py
+++ b/autogalaxy/util/plot_utils.py
@@ -133,13 +133,17 @@ def norm_from(array, use_log10=False, vmin=None, vmax=None):
     ``plot_*`` functions do, without needing a plotter object that the public
     namespaces no longer export.
 
-    The behaviour mirrors the normalisation applied inside
-    ``autoarray.plot.array.plot_array``.
+    The behaviour is not defined here: this is a thin delegate to
+    ``autoarray.plot.utils.norm_from``, the one implementation every PyAuto
+    colour scale is built from. It used to be a third copy of that logic, and
+    the copies had diverged — see the autoarray helper's docstring for the
+    behaviour and for which divergence was resolved which way. Only the name
+    is autogalaxy's, so the GUI callers keep working.
 
     Parameters
     ----------
     array
-        The image being normalised. Only read when *use_log10* is ``True`` and
+        The values being coloured. Only read when *use_log10* is ``True`` and
         no explicit *vmax* is given.
     use_log10
         When ``True`` a ``LogNorm`` is applied, with values clipped at the
@@ -152,36 +156,9 @@ def norm_from(array, use_log10=False, vmin=None, vmax=None):
     -------
     matplotlib.colors.Normalize or None
     """
-    if use_log10:
-        try:
-            from autonerves import conf as _conf
+    from autoarray.plot.utils import norm_from as _norm_from
 
-            log10_min = _conf.instance["visualize"]["general"]["general"][
-                "log10_min_value"
-            ]
-        except Exception:
-            log10_min = 1.0e-4
-
-        clipped = np.clip(array, log10_min, None)
-        vmin_log = vmin if (vmin is not None and np.isfinite(vmin)) else log10_min
-        if vmax is not None and np.isfinite(vmax):
-            vmax_log = vmax
-        else:
-            with np.errstate(all="ignore"):
-                vmax_log = np.nanmax(clipped)
-        if not np.isfinite(vmax_log) or vmax_log <= vmin_log:
-            vmax_log = vmin_log * 10.0
-
-        from matplotlib.colors import LogNorm
-
-        return LogNorm(vmin=vmin_log, vmax=vmax_log)
-
-    if vmin is not None or vmax is not None:
-        from matplotlib.colors import Normalize
-
-        return Normalize(vmin=vmin, vmax=vmax)
-
-    return None
+    return _norm_from(array=array, use_log10=use_log10, vmin=vmin, vmax=vmax)
 
 
 def _resolve_format(output_format):


### PR DESCRIPTION
## Summary

Companion to PyAutoLabs/PyAutoArray#489 (issue PyAutoLabs/PyAutoArray#488).

`norm_from` was added by #586 as a faithful copy of the colour-norm block in autoarray's `plot_array` — the third copy of logic that had already diverged across the three sites. PyAutoArray#489 makes that block one shared helper, so this becomes a thin delegate rather than a third copy.

autogalaxy may import autoarray (the dependency direction is fine; the reverse is not), and the name stays autogalaxy's so the `Clicker` / `Scribbler` callers added in #586 keep working unchanged.

**Library-first: PyAutoArray#489 must merge before this.** This PR's tests pass against `main` too — the helper it delegates to is behaviour-identical to what this function already implemented — but the import target only exists once #489 lands.

## API Changes

None. `autogalaxy.util.plot_utils.norm_from(array, use_log10=False, vmin=None, vmax=None)` keeps its name, signature and return contract; only its body changes, from a copy of the logic to a call into `autoarray.plot.utils.norm_from`.

Behaviour here is unchanged: the log10-floor path this function already implemented is the one the autoarray helper implements. The two deliberate behaviour changes in #489 both land on `plot_inversion_reconstruction`, which this repo does not call.

## Test Plan

- [x] `test_autogalaxy/gui/test_plot_norm.py` — 9 passed, **file untouched**. This is the test #586 added to pin the behaviour, so its staying green unmodified is the evidence that the delegation is faithful.
- [x] `test_autogalaxy` full suite against the PyAutoArray#489 branch — 1119 passed, 1 skipped
- [x] `Clicker` / `Scribbler` call sites unchanged and covered by the suite

Ran on Python 3.12 only — the authoring session had no 3.13 environment. CI covers 3.13.

<details>
<summary>Full API Changes (for automation &amp; release notes)</summary>

### Removed
- Nothing.

### Added
- Nothing.

### Migration
- None. The change is internal to `autogalaxy.util.plot_utils.norm_from`; the docstring now points at `autoarray.plot.utils.norm_from` for the behaviour and for which of the three divergences was resolved which way.

</details>

Generated by the PyAutoLabs agent workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DamasCoRrENvgiRkU5WHHW)_