### PR TITLE
feat: prior configs + docs for the AdaptPower regularization siblings

### DIFF
--- a/autogalaxy/config/priors/regularization/adapt_power.yaml
+++ b/autogalaxy/config/priors/regularization/adapt_power.yaml
@@ -1,0 +1,34 @@
+AdaptPower:
+  inner_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  outer_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  signal_scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  power:
+    type: Constant
+    value: 1.0

--- a/autogalaxy/config/priors/regularization/adapt_split_power.yaml
+++ b/autogalaxy/config/priors/regularization/adapt_split_power.yaml
@@ -1,0 +1,34 @@
+AdaptSplitPower:
+  inner_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  outer_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  signal_scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  power:
+    type: Constant
+    value: 1.0

--- a/autogalaxy/config/priors/regularization/adapt_split_zeroth_power.yaml
+++ b/autogalaxy/config/priors/regularization/adapt_split_zeroth_power.yaml
@@ -1,0 +1,54 @@
+AdaptSplitZerothPower:
+  zeroth_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  zeroth_signal_scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  inner_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  outer_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  signal_scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  power:
+    type: Constant
+    value: 1.0

--- a/autogalaxy/config/priors/regularization/matern_adapt_power_kernel.yaml
+++ b/autogalaxy/config/priors/regularization/matern_adapt_power_kernel.yaml
@@ -1,0 +1,54 @@
+MaternAdaptPowerKernel:
+  scale:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  nu:
+    type: Uniform
+    lower_limit: 0.5
+    upper_limit: 5.5
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  inner_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  outer_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  signal_scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  power:
+    type: Constant
+    value: 1.0

--- a/docs/api/pixelization.rst
+++ b/docs/api/pixelization.rst
@@ -69,6 +69,8 @@ Regularization [ag.reg]
    ConstantSplit
    Adapt
    AdaptSplit
+   AdaptPower
+   AdaptSplitPower
 
 Settings
 --------

--- a/test_autogalaxy/test_regularization_power.py
+++ b/test_autogalaxy/test_regularization_power.py
@@ -1,0 +1,38 @@
+"""
+Model-composition gate for the ``*Power`` regularization siblings added in PyAutoArray.
+
+These schemes are re-exported as ``ag.reg.*`` and carry their own prior configs
+(``autogalaxy/config/priors/regularization/*_power.yaml``). Composing them proves both the re-export
+chain and that the prior config resolves — including ``power``, which is fixed as a ``Constant``
+prior so a non-linear search never samples it.
+"""
+
+import autofit as af
+import autogalaxy as ag
+
+
+def test__power_classes_are_re_exported():
+    assert ag.reg.AdaptPower is not ag.reg.Adapt
+    assert ag.reg.AdaptSplitPower is not ag.reg.AdaptSplit
+    assert ag.reg.AdaptSplitZerothPower is not ag.reg.AdaptSplitZeroth
+    assert ag.reg.MaternAdaptPowerKernel is not ag.reg.MaternAdaptKernel
+
+
+def test__model_composition__power_is_a_constant_and_is_not_sampled():
+    model = af.Model(ag.reg.AdaptSplitPower)
+
+    assert "power" not in [prior_tuple[0] for prior_tuple in model.prior_tuples]
+    assert model.instance_from_prior_medians().power == 1.0
+
+    assert set(prior_tuple[0] for prior_tuple in model.prior_tuples) == {
+        "inner_coefficient",
+        "outer_coefficient",
+        "signal_scale",
+    }
+
+
+def test__model_identifier__differs_from_the_legacy_class():
+    identifier_legacy = af.Model(ag.reg.AdaptSplit).identifier
+    identifier_power = af.Model(ag.reg.AdaptSplitPower).identifier
+
+    assert identifier_legacy != identifier_power


### PR DESCRIPTION
## Summary

Prior configs, API docs and a composition test for the four `*Power` regularization siblings added in **PyAutoLabs/PyAutoArray#512** (`AdaptPower`, `AdaptSplitPower`, `AdaptSplitZerothPower`, `MaternAdaptPowerKernel`).

- `autogalaxy/config/priors/regularization/{adapt_power,adapt_split_power,adapt_split_zeroth_power,matern_adapt_power_kernel}.yaml` are copies of their legacy counterparts — same `LogUniform(1e-6, 1e6)` coefficient priors, which under the new classes span λ² rather than λ⁴ — plus `power: {type: Constant, value: 1.0}` so the convention switch is never sampled by a search.
- `docs/api/pixelization.rst` gains `AdaptPower` / `AdaptSplitPower` in the `ag.reg` autosummary.
- `test_autogalaxy/test_regularization_power.py` proves the `ag.reg` re-export chain, that `af.Model` exposes exactly `inner_coefficient` / `outer_coefficient` / `signal_scale` (not `power`), and that the identifier differs from the legacy class.

> **CI note:** green here already. The PyAutoHeart reusable workflow clones each dependency library at the *matching branch if it exists*, and PyAutoArray#512 uses the same branch name, so this PR's CI tested against it. Library-first merge order still applies for `main`'s sake: **merge PyAutoLabs/PyAutoArray#512 first**, otherwise `main` here would reference `ag.reg.AdaptPower` before the symbol exists.

## API Changes

None to `autogalaxy` source — config, docs and test additions only. The new public symbols are added upstream in PyAutoLabs/PyAutoArray#512 and reach users here as `ag.reg.AdaptPower`, `ag.reg.AdaptSplitPower`, `ag.reg.AdaptSplitZerothPower`, `ag.reg.MaternAdaptPowerKernel`.
See full details below.

## Test Plan

- [x] `pytest test_autogalaxy/` — 1152 passed (with PyAutoArray#512 on `PYTHONPATH`)
- [x] `af.Model(ag.reg.AdaptSplitPower)` composes; `power` resolves to the `Constant` value `1.0` and is absent from the prior tuples
- [x] `af.Model(ag.reg.AdaptSplit).identifier != af.Model(ag.reg.AdaptSplitPower).identifier`
- [x] CI green on all four legs (unittest 3.12 / 3.13 / nojax, docs-build), tested against the PyAutoArray branch

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added

- Prior configs for `AdaptPower`, `AdaptSplitPower`, `AdaptSplitZerothPower` and `MaternAdaptPowerKernel` — the coefficient priors are unchanged copies of the legacy schemes' (`LogUniform(1e-6, 1e6)`), and `power` is a `Constant` prior fixed at `1.0`.
- `docs/api/pixelization.rst` autosummary entries for `AdaptPower` and `AdaptSplitPower`.

### Migration

- Before: `ag.reg.AdaptSplit(inner_coefficient=c, outer_coefficient=c)`
- After: `ag.reg.AdaptSplitPower(inner_coefficient=c**2, outer_coefficient=c**2)`
- The legacy schemes and their prior configs are untouched, so no migration is required — this is guidance for new work.

</details>

Depends on PyAutoLabs/PyAutoArray#512. Refs PyAutoLabs/PyAutoArray#511.

Generated by the PyAutoLabs agent workflow.
