### PR TITLE
perf(mass): scipy wofz on the numpy MGE/Gaussian path, spherical MGE branch, Faddeeva dedupe (#596)

### DIFF
--- a/autogalaxy/profiles/mass/abstract/mge.py
+++ b/autogalaxy/profiles/mass/abstract/mge.py
@@ -1,7 +1,201 @@
 import numpy as np
+from scipy import special
 
 import autoarray as aa
+from autogalaxy import convert
 from autogalaxy.profiles.mass.abstract.abstract import MassProfile
+
+# Coefficients of the Poppe-Wijers / Zaghloul-Ali rational approximations used by
+# `_wofz_rational`. Hoisted to module level (as plain Python tuples) so the JAX
+# path neither rebuilds them nor traces a 0-d array constant per call.
+_WOFZ_R1_S1 = (2.5, 2.0, 1.5, 1.0, 0.5)
+
+_WOFZ_U5 = (1.320522, 35.7668, 219.031, 1540.787, 3321.990, 36183.31)
+_WOFZ_V5 = (1.841439, 61.57037, 364.2191, 2186.181, 9022.228, 24322.84, 32066.6)
+
+_WOFZ_U6 = (5.9126262, 30.180142, 93.15558, 181.92853, 214.38239, 122.60793)
+_WOFZ_V6 = (
+    10.479857,
+    53.992907,
+    170.35400,
+    348.70392,
+    457.33448,
+    352.73063,
+    122.60793,
+)
+
+_INV_SQRT_PI = float(1.0 / np.sqrt(np.pi))
+
+
+def _wofz_rational(z, xp=np):
+    """
+    JAX-compatible Faddeeva function w(z) = exp(-z^2) * erfc(-i z)
+    Based on the Poppe-Wijers / Zaghloul-Ali rational approximations.
+    Valid for all complex z. JIT + autodiff safe.
+
+    This is the hand-rolled routine used on the JAX path, where
+    `scipy.special.wofz` is not traceable. Its accuracy is ~6 significant
+    digits (max relative error 3.0e-6 against an mpmath reference at dps 40),
+    against 1.3e-14 for `scipy.special.wofz` -- which is why the numpy path
+    calls scipy instead (see `_wofz`).
+    """
+
+    z = xp.asarray(z, dtype=xp.complex128)
+    x = xp.real(z)
+    y = xp.imag(z)
+
+    r2 = x * x + y * y
+    y2 = y * y
+    z2 = z * z
+
+    # ---------- Large-|z| continued fraction ----------
+    t = z
+    for c in _WOFZ_R1_S1:
+        t = z - c / t
+
+    w_large = 1j * _INV_SQRT_PI / t
+
+    # ---------- Region 5 ----------
+    t = _INV_SQRT_PI
+    for u in _WOFZ_U5:
+        t = u + z2 * t
+
+    s = 1.0
+    for v in _WOFZ_V5:
+        s = v + z2 * s
+
+    real_exp = xp.clip(-xp.real(z2), None, 700.0)
+    imag_exp = -xp.imag(z2)
+    w5 = (
+        xp.exp(real_exp + 1j * imag_exp) + 1j * z * t / s
+    )  # clip prevents overflow error
+
+    # ---------- Region 6 ----------
+    t = _INV_SQRT_PI
+    for u in _WOFZ_U6:
+        t = u - 1j * z * t
+
+    s = 1.0
+    for v in _WOFZ_V6:
+        s = v - 1j * z * s
+
+    w6 = t / s
+
+    # ---------- Region logic ----------
+    reg1 = (r2 >= 62.0) | ((r2 >= 30.0) & (r2 < 62.0) & (y2 >= 1e-13))
+    reg2 = ((r2 >= 30) & (r2 < 62) & (y2 < 1e-13)) | (
+        (r2 >= 2.5) & (r2 < 30) & (y2 < 0.072)
+    )
+
+    w = w6
+    w = xp.where(reg2, w5, w)
+    w = xp.where(reg1, w_large, w)
+
+    return w
+
+
+def _wofz(z, xp=np):
+    """
+    Faddeeva function w(z) = exp(-z^2) * erfc(-i z), dispatched on the array
+    backend: `scipy.special.wofz` on numpy (faster and ~8 orders of magnitude
+    more accurate), the hand-rolled `_wofz_rational` on JAX (traceable).
+    """
+    if xp is np:
+        return special.wofz(np.asarray(z, dtype=np.complex128))
+
+    return _wofz_rational(z, xp=xp)
+
+
+def _wofz_masked(z, exp_term, threshold: float = 1e-18):
+    """
+    `w(z)` on the numpy path, evaluated only where the Gaussian envelope it is about to
+    be multiplied by is significant.
+
+    `zeta_from` only ever passes Im(z) >= 0, where |w(z)| <= 1, so wherever `exp_term`
+    has underflowed the product is negligible to < 1e-15 and `w` is simply taken as
+    zero. On the (N_gaussians, N_pixels) arrays of an MGE ~32% of the entries qualify;
+    where nothing qualifies (a single Gaussian on a typical grid) the mask would be pure
+    overhead, so the full array is evaluated instead.
+    """
+    significant = exp_term > threshold
+
+    if significant.all():
+        return _wofz(z)
+
+    w = np.zeros(np.shape(z), dtype=np.complex128)
+    w[significant] = _wofz(z[significant])
+    return w
+
+
+def _is_circular(ell_comps) -> bool:
+    """
+    Whether the *unclamped* geometry of a profile is exactly circular (q = 1).
+
+    The axis ratio used inside the MGE machinery is clamped to 0.9999 (the
+    elliptical Faddeeva form is singular at q = 1), so it can never be used to
+    detect a spherical profile -- this reads the profile's own ellipticity
+    components instead.
+    """
+    return float(convert.axis_ratio_from(ell_comps=ell_comps)) == 1.0
+
+
+def _spherical_mge_deflections_from(grid, amps, sigmas):
+    r"""
+    Deflection angles of a circular (q = 1) Multi-Gaussian Expansion, in closed
+    form on the numpy path.
+
+    For a circular Gaussian of convergence :math:`A_j \exp(-r^2/2\sigma_j^2)`
+    the deflection is purely radial, so the elliptical Faddeeva sum reduces
+    exactly (its q -> 1 limit) to
+
+    .. math::
+
+        \alpha_r(r) = \sum_j \frac{2 A_j \sigma_j^2}{r}
+                      \left(1 - e^{-r^2 / 2\sigma_j^2}\right)
+
+    which is evaluated here in real arithmetic, with :math:`\alpha_r(0) = 0`.
+    Evaluating a spherical profile through the elliptical path at the q = 0.9999
+    clamp instead costs a complex `(N_gaussians, N_pixels)` Faddeeva evaluation
+    and carries a ~6e-5 relative bias plus a spurious cross-axis deflection.
+
+    Parameters
+    ----------
+    grid
+        The (y,x) coordinates in the profile's reference frame.
+    amps
+        The amplitudes :math:`A_j` of the Gaussian components.
+    sigmas
+        The widths :math:`\sigma_j` of the Gaussian components.
+
+    Returns
+    -------
+    The (y,x) deflection angles, in the profile's reference frame.
+    """
+    y = np.asarray(grid.array[:, 0], dtype=np.float64)
+    x = np.asarray(grid.array[:, 1], dtype=np.float64)
+
+    amps = np.asarray(amps, dtype=np.float64)[:, None]
+    sigmas = np.asarray(sigmas, dtype=np.float64)[:, None]
+
+    radii_squared = y * y + x * x
+
+    magnitude = np.sum(
+        2.0
+        * amps
+        * sigmas**2.0
+        * -np.expm1(-0.5 * radii_squared[None, :] / sigmas**2.0),
+        axis=0,
+    )
+
+    # magnitude / r gives alpha_r, and the unit vector another 1 / r.
+    factor = np.divide(
+        magnitude,
+        radii_squared,
+        out=np.zeros_like(magnitude),
+        where=radii_squared > 0.0,
+    )
+
+    return np.vstack((factor * y, factor * x)).T
 
 
 class MGEDecomposer:
@@ -79,93 +273,15 @@ class MGEDecomposer:
     @staticmethod
     def wofz(z, xp=np):
         """
-        JAX-compatible Faddeeva function w(z) = exp(-z^2) * erfc(-i z)
-        Based on the Poppe–Wijers / Zaghloul–Ali rational approximations.
-        Valid for all complex z. JIT + autodiff safe.
+        Faddeeva function w(z) = exp(-z^2) * erfc(-i z), valid for all complex z.
+
+        The numpy path calls `scipy.special.wofz`; the JAX path calls the
+        hand-rolled `_wofz_rational` (the Poppe-Wijers / Zaghloul-Ali rational
+        approximations), which is JIT + autodiff safe. The split exists because
+        scipy is not traceable under JAX, and because scipy is both faster and
+        far more accurate (1.3e-14 vs 3.0e-6 max relative error against mpmath).
         """
-
-        z = xp.asarray(z, dtype=xp.complex128)
-        x = xp.real(z)
-        y = xp.imag(z)
-
-        r2 = x * x + y * y
-        y2 = y * y
-        z2 = z * z
-
-        sqrt_pi = xp.asarray(xp.sqrt(xp.pi), dtype=xp.float64)
-        inv_sqrt_pi = xp.asarray(1.0 / sqrt_pi, dtype=xp.float64)
-
-        # ---------- Large-|z| continued fraction ----------
-        r1_s1 = xp.asarray([2.5, 2.0, 1.5, 1.0, 0.5], dtype=xp.float64)
-
-        t = z
-        for c in r1_s1:
-            t = z - c / t
-
-        w_large = 1j * inv_sqrt_pi / t
-
-        # ---------- Region 5 ----------
-        U5 = xp.asarray(
-            [1.320522, 35.7668, 219.031, 1540.787, 3321.990, 36183.31], dtype=xp.float64
-        )
-        V5 = xp.asarray(
-            [1.841439, 61.57037, 364.2191, 2186.181, 9022.228, 24322.84, 32066.6],
-            dtype=xp.float64,
-        )
-
-        t = inv_sqrt_pi
-        for u in U5:
-            t = u + z2 * t
-
-        s = xp.asarray(1.0, dtype=xp.float64)
-        for v in V5:
-            s = v + z2 * s
-
-        real_exp = xp.clip(-xp.real(z2), None, 700.0)
-        imag_exp = -xp.imag(z2)
-        w5 = (
-            xp.exp(real_exp + 1j * imag_exp) + 1j * z * t / s
-        )  # clip prevents overflow error
-
-        # ---------- Region 6 ----------
-        U6 = xp.asarray(
-            [5.9126262, 30.180142, 93.15558, 181.92853, 214.38239, 122.60793],
-            dtype=xp.float64,
-        )
-        V6 = xp.asarray(
-            [
-                10.479857,
-                53.992907,
-                170.35400,
-                348.70392,
-                457.33448,
-                352.73063,
-                122.60793,
-            ],
-            dtype=xp.float64,
-        )
-
-        t = inv_sqrt_pi
-        for u in U6:
-            t = u - 1j * z * t
-
-        s = xp.asarray(1.0, dtype=xp.float64)
-        for v in V6:
-            s = v - 1j * z * s
-
-        w6 = t / s
-
-        # ---------- Region logic ----------
-        reg1 = (r2 >= 62.0) | ((r2 >= 30.0) & (r2 < 62.0) & (y2 >= 1e-13))
-        reg2 = ((r2 >= 30) & (r2 < 62) & (y2 < 1e-13)) | (
-            (r2 >= 2.5) & (r2 < 30) & (y2 < 0.072)
-        )
-
-        w = w6
-        w = xp.where(reg2, w5, w)
-        w = xp.where(reg1, w_large, w)
-
-        return w
+        return _wofz(z, xp=xp)
 
     @aa.decorators.to_vector_yx
     @aa.decorators.transform
@@ -199,20 +315,29 @@ class MGEDecomposer:
         """
         sigma_log_array = xp.asarray(sigma_log_list, dtype=xp.float64)
 
-        amps, sigmas = self.decompose_convergence_via_mge(
+        amps, _ = self.decompose_convergence_via_mge(
             sigma_log_list=sigma_log_array,
             func_terms=func_terms,
             three_D=three_D,
             xp=xp,
         )
 
-        q = xp.asarray(self.axis_ratio(xp), dtype=xp.float64)
-
         # Change ellipticity convention to (q**2*x**2 + y**2) (most profiles are in (x**2 + y**2/q**2))
         sigmas_factor = self.sigmas_factor_from(
             input_convention=ellipticity_convention, target_convention="minor", xp=xp
         )
         sigmas = sigmas_factor * sigma_log_array
+
+        if xp is np and _is_circular(self.ell_comps):
+            # A spherical profile has an exact real radial form -- take it instead of
+            # the complex Faddeeva sum evaluated at the q = 0.9999 clamp. JAX keeps
+            # the elliptical path (no data-dependent branching under a trace).
+            return self.mass_profile.rotated_grid_from_reference_frame_from(
+                _spherical_mge_deflections_from(grid=grid, amps=amps, sigmas=sigmas),
+                xp=xp,
+            )
+
+        q = xp.asarray(self.axis_ratio(xp), dtype=xp.float64)
 
         deflection_angles = (
             amps[:, None]
@@ -313,7 +438,12 @@ class MGEDecomposer:
 
         exp_term = xp.exp(-(xs * xs) * (1.0 - q2) - (ys * ys) * (1.0 / q2 - 1.0))
 
-        core = -1j * (self.wofz(z1, xp=xp) - exp_term * self.wofz(z2, xp=xp))
+        if xp is np:
+            w2 = _wofz_masked(z2, exp_term)
+        else:
+            w2 = self.wofz(z2, xp=xp)
+
+        core = -1j * (self.wofz(z1, xp=xp) - exp_term * w2)
 
         return xp.where(ind_pos_y[None, :], core, xp.conj(core))
 
@@ -506,7 +636,7 @@ class MGEDecomposer:
         """
         sigma_log_array = xp.asarray(sigma_log_list, dtype=xp.float64)
 
-        amps, sigmas = self.decompose_convergence_via_mge(
+        amps, _ = self.decompose_convergence_via_mge(
             sigma_log_list=sigma_log_array,
             func_terms=func_terms,
             three_D=three_D,

--- a/autogalaxy/profiles/mass/stellar/gaussian.py
+++ b/autogalaxy/profiles/mass/stellar/gaussian.py
@@ -5,6 +5,12 @@ from typing import Tuple
 import autoarray as aa
 
 from autogalaxy.profiles.mass.abstract.abstract import MassProfile
+from autogalaxy.profiles.mass.abstract.mge import (
+    MGEDecomposer,
+    _is_circular,
+    _spherical_mge_deflections_from,
+    _wofz_masked,
+)
 from autogalaxy.profiles.mass.stellar.abstract import StellarProfile
 
 
@@ -88,6 +94,16 @@ class Gaussian(MassProfile, StellarProfile):
 
         """
 
+        if xp is np and _is_circular(self.ell_comps):
+            # A circular Gaussian has an exact real radial form -- take it instead of
+            # the complex Faddeeva evaluated at the q = 0.9999 clamp. JAX keeps the
+            # elliptical path (no data-dependent branching under a trace).
+            return _spherical_mge_deflections_from(
+                grid=grid,
+                amps=np.array([self.mass_to_light_ratio * self.intensity]),
+                sigmas=np.array([self.sigma]),
+            )
+
         deflections = (
             self.mass_to_light_ratio
             * self.intensity
@@ -123,8 +139,6 @@ class Gaussian(MassProfile, StellarProfile):
     @aa.decorators.to_array
     @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
-        from autogalaxy.profiles.mass.abstract.mge import MGEDecomposer
-
         radii_min = self.sigma / 100.0
         radii_max = self.sigma * 20.0
         sigmas = xp.exp(xp.linspace(xp.log(radii_min), xp.log(radii_max), 100))
@@ -182,97 +196,15 @@ class Gaussian(MassProfile, StellarProfile):
 
         exp_term = xp.exp(-(xs * xs) * (1.0 - q2) - (ys * ys) * (1.0 / q2 - 1.0))
 
-        core = -1j * (self.wofz(z1, xp=xp) - exp_term * self.wofz(z2, xp=xp))
+        if xp is np:
+            w2 = _wofz_masked(z2, exp_term)
+        else:
+            w2 = self.wofz(z2, xp=xp)
+
+        core = -1j * (self.wofz(z1, xp=xp) - exp_term * w2)
 
         return xp.where(ind_pos_y, core, xp.conj(core))
 
-    @staticmethod
-    def wofz(z, xp=np):
-        """
-        JAX-compatible Faddeeva function w(z) = exp(-z^2) * erfc(-i z)
-        Based on the Poppe–Wijers / Zaghloul–Ali rational approximations.
-        Valid for all complex z. JIT + autodiff safe.
-        """
-
-        z = xp.asarray(z, dtype=xp.complex128)
-        x = xp.real(z)
-        y = xp.imag(z)
-
-        r2 = x * x + y * y
-        y2 = y * y
-        z2 = z * z
-
-        sqrt_pi = xp.asarray(xp.sqrt(xp.pi), dtype=xp.float64)
-        inv_sqrt_pi = xp.asarray(1.0 / sqrt_pi, dtype=xp.float64)
-
-        # ---------- Large-|z| continued fraction ----------
-        r1_s1 = xp.asarray([2.5, 2.0, 1.5, 1.0, 0.5], dtype=xp.float64)
-
-        t = z
-        for c in r1_s1:
-            t = z - c / t
-
-        w_large = 1j * inv_sqrt_pi / t
-
-        # ---------- Region 5 ----------
-        U5 = xp.asarray(
-            [1.320522, 35.7668, 219.031, 1540.787, 3321.990, 36183.31], dtype=xp.float64
-        )
-        V5 = xp.asarray(
-            [1.841439, 61.57037, 364.2191, 2186.181, 9022.228, 24322.84, 32066.6],
-            dtype=xp.float64,
-        )
-
-        t = inv_sqrt_pi
-        for u in U5:
-            t = u + z2 * t
-
-        s = xp.asarray(1.0, dtype=xp.float64)
-        for v in V5:
-            s = v + z2 * s
-
-        real_exp = xp.clip(-xp.real(z2), None, 700.0)
-        imag_exp = -xp.imag(z2)
-        w5 = (
-            xp.exp(real_exp + 1j * imag_exp) + 1j * z * t / s
-        )  # clip prevents overflow error
-
-        # ---------- Region 6 ----------
-        U6 = xp.asarray(
-            [5.9126262, 30.180142, 93.15558, 181.92853, 214.38239, 122.60793],
-            dtype=xp.float64,
-        )
-        V6 = xp.asarray(
-            [
-                10.479857,
-                53.992907,
-                170.35400,
-                348.70392,
-                457.33448,
-                352.73063,
-                122.60793,
-            ],
-            dtype=xp.float64,
-        )
-
-        t = inv_sqrt_pi
-        for u in U6:
-            t = u - 1j * z * t
-
-        s = xp.asarray(1.0, dtype=xp.float64)
-        for v in V6:
-            s = v - 1j * z * s
-
-        w6 = t / s
-
-        # ---------- Region logic ----------
-        reg1 = (r2 >= 62.0) | ((r2 >= 30.0) & (r2 < 62.0) & (y2 >= 1e-13))
-        reg2 = ((r2 >= 30) & (r2 < 62) & (y2 < 1e-13)) | (
-            (r2 >= 2.5) & (r2 < 30) & (y2 < 0.072)
-        )
-
-        w = w6
-        w = xp.where(reg2, w5, w)
-        w = xp.where(reg1, w_large, w)
-
-        return w
+    # One Faddeeva body for the whole library: `staticmethod` is load-bearing, a
+    # bare assignment would bind `self` as `z` at the `self.wofz(z1, xp=xp)` call.
+    wofz = staticmethod(MGEDecomposer.wofz)

--- a/test_autogalaxy/profiles/mass/abstract/test_mge.py
+++ b/test_autogalaxy/profiles/mass/abstract/test_mge.py
@@ -664,3 +664,74 @@ def test__sersic_convergence_2d_via_mge_from__elliptical():
     )
 
     assert convergence == pytest.approx(5.38066670129, 1e-3)
+
+
+def test__wofz__numpy_path_is_scipy__rational_path_agrees_to_1e_4():
+    """The numpy path is `scipy.special.wofz` itself (max relative error 1.3e-14 against
+    an mpmath reference at dps 40); the hand-rolled rational routine kept for JAX is
+    accurate to ~6 significant digits (3.0e-6 against the same reference)."""
+    from scipy.special import wofz
+
+    from autogalaxy.profiles.mass.abstract.mge import _wofz_rational
+
+    z_list = [
+        20.0 + 1j * 0.001,
+        7.0 + 1j * 0.1,
+        7.0 + 1j * 1e-11,
+        2.0 + 1j * 0.001,
+        2.0 + 1j * 1.0,
+        1.0 + 1j * 0.001,
+    ]
+
+    for z in z_list:
+        assert MGEDecomposer.wofz(z) == pytest.approx(wofz(z), rel=1.0e-12)
+        assert _wofz_rational(z) == pytest.approx(wofz(z), rel=1.0e-4)
+
+
+def test__deflections_2d_via_mge_from__spherical_case__is_radial_and_matches_elliptical_limit(
+    monkeypatch,
+):
+    """A profile whose *unclamped* axis ratio is exactly 1 takes the exact radial closed
+    form on the numpy path, instead of an elliptical Faddeeva sum at the q = 0.9999 clamp.
+
+    The deflection of a circular profile is exactly radial (no cross-axis component on
+    the axes; the clamped elliptical path leaves a spurious ~1e-8 one), and it matches
+    the elliptical form in its q -> 1 limit. Reaching that limit needs the 0.9999 clamp
+    lifted -- the clamp *is* the ~6e-5 bias the branch removes -- so it is monkeypatched
+    away for the comparison only.
+    """
+    gnfw_sph = ag.mp.gNFWSph(
+        centre=(0.0, 0.0), kappa_s=0.2, inner_slope=1.5, scale_radius=10.0
+    )
+
+    grid_axes = ag.Grid2DIrregular([[1.0, 0.0], [0.0, 2.5], [-1.7, 0.0], [0.0, 0.0]])
+
+    deflections = gnfw_sph.deflections_yx_2d_from(grid=grid_axes)
+
+    assert deflections[0, 1] == 0.0
+    assert deflections[1, 0] == 0.0
+    assert deflections[2, 1] == 0.0
+    assert deflections[3, 0] == 0.0 and deflections[3, 1] == 0.0
+
+    monkeypatch.setattr(
+        MGEDecomposer,
+        "axis_ratio",
+        lambda self, xp=np: self.mass_profile.axis_ratio(xp=xp),
+    )
+
+    ell_comps = ag.convert.ell_comps_from(axis_ratio=0.999999, angle=0.0)
+
+    gnfw_ell = ag.mp.gNFW(
+        centre=(0.0, 0.0),
+        ell_comps=(float(ell_comps[0]), float(ell_comps[1])),
+        kappa_s=0.2,
+        inner_slope=1.5,
+        scale_radius=10.0,
+    )
+
+    grid = ag.Grid2DIrregular([[0.5, 1.0], [-2.0, 0.3], [1.5, -1.5], [0.05, 0.05]])
+
+    deflections_sph = np.asarray(gnfw_sph.deflections_yx_2d_from(grid=grid).array)
+    deflections_ell = np.asarray(gnfw_ell.deflections_yx_2d_from(grid=grid).array)
+
+    assert deflections_sph == pytest.approx(deflections_ell, rel=1.0e-5)

--- a/test_autogalaxy/profiles/mass/stellar/test_gaussian.py
+++ b/test_autogalaxy/profiles/mass/stellar/test_gaussian.py
@@ -223,15 +223,16 @@ def test__image_2d_via_radii_from__sigma_2_radii_3():
 
 
 def test__wofz__regions_1_2_3():
+    """The hand-rolled rational approximation is the JAX-path routine (numpy goes to
+    `scipy.special.wofz`), so these region pins target it directly -- the suite never
+    imports jax, and `MGEDecomposer.wofz` would dispatch away from the branches."""
     from scipy.special import wofz
 
-    mp = ag.mp.Gaussian(
-        centre=(0.0, 0.0), ell_comps=(0.0, 0.0), intensity=1.0, sigma=2.0
-    )
+    from autogalaxy.profiles.mass.abstract.mge import _wofz_rational as mp_wofz
 
-    wofz_approx_reg_1 = mp.wofz(20.0 + 1j * 0.001)
-    wofz_approx_reg_2 = mp.wofz(2.0 + 1j * 0.001)
-    wofz_approx_reg_3 = mp.wofz(1.0 + 1j * 0.001)
+    wofz_approx_reg_1 = mp_wofz(20.0 + 1j * 0.001)
+    wofz_approx_reg_2 = mp_wofz(2.0 + 1j * 0.001)
+    wofz_approx_reg_3 = mp_wofz(1.0 + 1j * 0.001)
 
     assert wofz_approx_reg_1 == pytest.approx(wofz(20.0 + 1j * 0.001), 1e-4)
     assert wofz_approx_reg_2 == pytest.approx(wofz(2.0 + 1j * 0.001), 1e-4)
@@ -239,16 +240,63 @@ def test__wofz__regions_1_2_3():
 
 
 def test__wofz__regions_4_5_6():
+    """See `test__wofz__regions_1_2_3`: these pin the JAX-path rational routine."""
     from scipy.special import wofz
 
-    mp = ag.mp.Gaussian(
-        centre=(0.0, 0.0), ell_comps=(0.0, 0.0), intensity=1.0, sigma=2.0
-    )
+    from autogalaxy.profiles.mass.abstract.mge import _wofz_rational as mp_wofz
 
-    wofz_approx_reg_1 = mp.wofz(7.0 + 1j * 0.1)
-    wofz_approx_reg_2 = mp.wofz(7.0 + 1j * 1e-11)
-    wofz_approx_reg_3 = mp.wofz(2.0 + 1j * 1.0)
+    wofz_approx_reg_1 = mp_wofz(7.0 + 1j * 0.1)
+    wofz_approx_reg_2 = mp_wofz(7.0 + 1j * 1e-11)
+    wofz_approx_reg_3 = mp_wofz(2.0 + 1j * 1.0)
 
     assert wofz_approx_reg_1 == pytest.approx(wofz(7.0 + 1j * 0.1), 1e-4)
     assert wofz_approx_reg_2 == pytest.approx(wofz(7.0 + 1j * 1e-11), 1e-4)
     assert wofz_approx_reg_3 == pytest.approx(wofz(2.0 + 1j * 1.0), 1e-4)
+
+
+def test__deflections_yx_2d_from__spherical_case__is_radial_and_matches_elliptical_limit(
+    monkeypatch,
+):
+    """`Gaussian(ell_comps=(0, 0))` takes the exact radial closed form on the numpy path.
+
+    Two checks: the deflection of a circular profile is purely radial (no cross-axis
+    component on the axes, down to the rounding of the grid rotate-back, which is what
+    the ~5e-18 tolerance below allows for), and it matches the elliptical Faddeeva form
+    in its q -> 1 limit. That limit is only reachable with the 0.9999 clamp lifted --
+    the clamp *is* the ~6e-5 bias this branch removes -- so it is monkeypatched away for
+    the comparison only.
+    """
+    gaussian_sph = ag.mp.Gaussian(
+        centre=(0.0, 0.0), ell_comps=(0.0, 0.0), intensity=0.1, sigma=1.0
+    )
+
+    grid_axes = ag.Grid2DIrregular([[1.0, 0.0], [0.0, 2.5], [-1.7, 0.0], [0.0, 0.0]])
+
+    deflections = gaussian_sph.deflections_yx_2d_from(grid=grid_axes)
+
+    assert deflections[0, 1] == pytest.approx(0.0, abs=1.0e-17)
+    assert deflections[1, 0] == pytest.approx(0.0, abs=1.0e-17)
+    assert deflections[2, 1] == pytest.approx(0.0, abs=1.0e-17)
+    assert deflections[3, 0] == 0.0 and deflections[3, 1] == 0.0
+
+    monkeypatch.setattr(
+        ag.mp.Gaussian,
+        "axis_ratio",
+        lambda self, xp=np: ag.convert.axis_ratio_from(ell_comps=self.ell_comps, xp=xp),
+    )
+
+    ell_comps = ag.convert.ell_comps_from(axis_ratio=0.999999, angle=0.0)
+
+    gaussian_ell = ag.mp.Gaussian(
+        centre=(0.0, 0.0),
+        ell_comps=(float(ell_comps[0]), float(ell_comps[1])),
+        intensity=0.1,
+        sigma=1.0,
+    )
+
+    grid = ag.Grid2DIrregular([[0.5, 1.0], [-2.0, 0.3], [1.5, -1.5], [0.05, 0.05]])
+
+    deflections_sph = np.asarray(gaussian_sph.deflections_yx_2d_from(grid=grid).array)
+    deflections_ell = np.asarray(gaussian_ell.deflections_yx_2d_from(grid=grid).array)
+
+    assert deflections_sph == pytest.approx(deflections_ell, rel=1.0e-5)


### PR DESCRIPTION
## Summary

Phase 2 of the `numpy-deflections-cpu` epic (#596). After phase 1 the MGE-decomposed profiles were the slowest numpy deflections, all of the cost in a hand-rolled three-branch Faddeeva routine evaluated on a `(30, N)` complex128 array twice per call, with the spherical members paying it as an *elliptical* MGE at the `q = 0.9999` clamp.

- `MGEDecomposer.wofz` dispatches: `scipy.special.wofz` when `xp is np`; the hand-rolled rational approximation (`_wofz_rational`, coefficients hoisted to module tuples, Python-float accumulators) under JAX. A jitted gNFW deflection is bit-identical before and after (max abs diff 0.0).
- `Gaussian.wofz` was a byte-identical copy; it is now `staticmethod(MGEDecomposer.wofz)`, one body.
- `_wofz_masked` skips the second Faddeeva evaluation where the Gaussian envelope has underflowed (~32 % of the `(30, N)` entries); only `Im(z) ≥ 0` is ever passed, where `|w(z)| ≤ 1`, so the skipped product is negligible to < 1e-15. Falls back to the full evaluation when nothing underflows (the single-Gaussian case, where the mask would cost 1.16×).
- `_spherical_mge_deflections_from`: when the profile's *unclamped* axis ratio is exactly 1, the exact radial form `α_r(r) = Σ_j 2 A_j σ_j² (1 − e^{−r²/2σ_j²}) / r` is used on the numpy path by the MGE deflections and by `Gaussian`. JAX keeps the elliptical path.

Evidence: against an mpmath reference (dps 40) the hand-rolled routine has max relative error 3.0e-6 and `scipy.special.wofz` 1.3e-14, so the ≤ 4e-6 relative deflection shifts are corrections. The spherical form is the exact q → 1 limit (the elliptical path converges to it linearly in 1 − q: gNFWSph 6.4e-4 at q = 0.999, 6.4e-6 at 0.99999, 6.4e-7 at 0.999999), so the old clamped path carried a ~6e-5 relative bias and a spurious cross-axis deflection (one hst profiling sample pinned at −3.1e-8 is now exactly 0). The decomposition-cache lever from the prompt was dropped: `decompose_convergence_via_mge` is 0.34 ms/call.

Measured (autolens_profiling `scripts/lens/deflections/`, hst, 15,361 points, `OMP_NUM_THREADS=1`): gNFW 0.261 → 0.104 s (2.5×), gNFWSph 0.234 → 0.0042 s (56×), `Gaussian(ell_comps=(0,0))` 0.0077 → 0.0015 s (5×), elliptical Gaussian 0.0065 → 0.0058 s (1.1×; its inputs sit in scipy's series regime, no lever in scope). The profiling cells are re-pinned with this provenance in the companion autolens_profiling PR.

## API Changes
None — internal changes only. Numpy-path deflections of MGE-routed and `Gaussian` mass profiles move by ≤ 4e-6 relative (Faddeeva accuracy) and spherical MGE-routed profiles by ≤ ~1e-4 relative (clamp bias removed; cross-axis components on the symmetry axes become exactly 0).
See full details below.

## Test Plan
- [x] `test_autogalaxy`: 1161 passed (2 new: numpy `wofz` vs scipy rtol 1e-12 and `_wofz_rational` vs scipy rtol 1e-4 on the region probe points; spherical-branch radial/zero-cross-axis + agreement with the elliptical path at q = 0.999999). `test_gaussian.py` hand-rolled-branch tests retargeted at `_wofz_rational`. No existing literal moved (cNFWSph deflections are analytic, not MGE-routed).
- [x] `test_autolens`: 576 passed (downstream).
- [x] JAX identity probe: `jax.jit` gNFW deflections bit-identical (0.0).
- [x] mpmath adjudication of both Faddeeva routines.
- [ ] CI green; companion autolens_profiling PR merges after this one.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autogalaxy.profiles.mass.abstract.mge.MGEDecomposer.wofz` — on the numpy backend evaluates `scipy.special.wofz` (max rel error 1.3e-14) instead of the ~6-significant-figure rational approximation; the rational approximation remains the JAX-backend body (`_wofz_rational`).
- `autogalaxy.profiles.mass.stellar.gaussian.Gaussian.wofz` — now the same static method as `MGEDecomposer.wofz` (was a duplicate body).
- MGE-routed `deflections_yx_2d_from` (gNFW, gNFWSph and every other MGE-decomposed mass profile) and `Gaussian.deflections_yx_2d_from` — on the numpy backend, a profile whose unclamped axis ratio is exactly 1 takes an exact radial closed form instead of the elliptical kernel at the 0.9999 clamp (removes a ~6e-5 relative bias and spurious cross-axis deflections).

</details>

Generated by the PyAutoLabs agent workflow. Epic ledger: `PyAutoMind/draft/feature/autogalaxy/numpy_deflections_cpu_speedup.md`. Companion: autolens_profiling (after-pass, re-pinned cells, note). Follow-up filed for the JAX path (Faddeeva seams + spherical clamp audit): `PyAutoMind/draft/research/autogalaxy/jax_faddeeva_seams_and_spherical_clamp_audit.md`.
