### PR TITLE
perf: numpy deflections phase 3 — PowerLaw omega series, NFW masks, Isothermal hoists (#598)

### DIFF
--- a/autogalaxy/profiles/mass/dark/abstract.py
+++ b/autogalaxy/profiles/mass/dark/abstract.py
@@ -16,18 +16,29 @@ class DarkProfile:
 
 
 def coord_func_f_from(grid_radius, xp=np):
+    """
+    The NFW auxiliary function f(x): arccos(1/x) / sqrt(x^2 - 1) outside the scale radius,
+    arccosh(1/x) / sqrt(1 - x^2) inside it, and 1 on it.
+
+    The result has the dtype of the input: a real radius gives a real f (each branch is
+    evaluated on inputs masked into its own domain, so no branch sees a radius it is not
+    defined for), and a complex radius the complex continuation the gNFW family relies on.
+    """
     if isinstance(grid_radius, float) or isinstance(grid_radius, complex):
         grid_radius = xp.array([grid_radius])
 
-    f = xp.ones(shape=grid_radius.shape[0], dtype="complex64")
-
     r = grid_radius
-    inv_r = 1.0 / r
 
-    out_gt = (1.0 / xp.sqrt(r**2 - 1.0)) * xp.arccos(inv_r)
-    out_lt = (1.0 / xp.sqrt(1.0 - r**2)) * xp.arccosh(inv_r)
+    greater = r > 1.0
+    less = r < 1.0
 
-    return xp.where(r > 1.0, out_gt, xp.where(r < 1.0, out_lt, f))
+    r_gt = xp.where(greater, r, 2.0)
+    r_lt = xp.where(less, r, 0.5)
+
+    out_gt = xp.arccos(1.0 / r_gt) / xp.sqrt(r_gt**2 - 1.0)
+    out_lt = xp.arccosh(1.0 / r_lt) / xp.sqrt(1.0 - r_lt**2)
+
+    return xp.where(greater, out_gt, xp.where(less, out_lt, xp.ones_like(r)))
 
 
 class AbstractgNFW(MassProfile, DarkProfile):
@@ -163,12 +174,21 @@ class AbstractgNFW(MassProfile, DarkProfile):
         r = xp.real(grid_radius)
         r2 = r**2
 
+        # Each branch divides by (r^2 - 1), which is zero on the scale radius: mask the
+        # denominators into each branch's own domain so the excluded points are never
+        # divided by zero, then select.
+        greater = r > 1.0
+        less = r < 1.0
+
+        r2_gt = xp.where(greater, r2, 2.0)
+        r2_lt = xp.where(less, r2, 0.5)
+
         return xp.where(
-            r > 1.0,
-            (1.0 - f_r) / (r2 - 1.0),
+            greater,
+            (1.0 - f_r) / (r2_gt - 1.0),
             xp.where(
-                r < 1.0,
-                (f_r - 1.0) / (1.0 - r2),
+                less,
+                (f_r - 1.0) / (1.0 - r2_lt),
                 1.0 / 3.0,
             ),
         )

--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -104,38 +104,45 @@ class NFW(gNFW, MassProfileCSE):
         x1 = grid.array[:, 1] / self.scale_radius
         x2 = grid.array[:, 0] / self.scale_radius
 
-        r2 = x1**2 + x2**2
+        # The deflection at the exact centre is zero by symmetry, but the closed form divides
+        # by the radius there. The centre's inputs are masked to a harmless point on the unit
+        # ellipse before anything is evaluated (so no branch sees a zero radius) and its
+        # deflection is zeroed through the prefactor afterwards.
 
-        # Avoid nans
+        mask = x1**2 + x2**2 > 1e-24
 
-        mask = r2 > 1e-24
+        x1 = xp.where(mask, x1, 1.0)
+        x2 = xp.where(mask, x2, 0.0)
+
+        x1_sq = x1**2
+        x2_sq = x2**2
+        e_sq = e_hk24**2
+        r_sq = x1_sq + x2_sq
 
         prefactor = xp.where(
             mask,
             4
             * self.kappa_s
-            * xp.sqrt(1 - e_hk24**2)
-            / (((x1 - e_hk24) ** 2 + x2**2) * ((x1 + e_hk24) ** 2 + x2**2)),
+            * xp.sqrt(1 - e_sq)
+            / (((x1 - e_hk24) ** 2 + x2_sq) * ((x1 + e_hk24) ** 2 + x2_sq)),
             0.0,
         )
 
-        f1 = xp.where(mask, nfw_hk24_util.small_f_1(x1, x2, e_hk24, xp=xp), 0.0)
-        f2 = xp.where(mask, nfw_hk24_util.small_f_2(x1, x2, e_hk24, xp=xp), 0.0)
-        f3 = xp.where(mask, nfw_hk24_util.small_f_3(x1, x2, e_hk24, xp=xp), 0.0)
+        f1 = nfw_hk24_util.small_f_1(x1, x2, e_hk24, xp=xp)
+        f2 = nfw_hk24_util.small_f_2(x1, x2, e_hk24, xp=xp)
+        f3 = nfw_hk24_util.small_f_3(x1, x2, e_hk24, xp=xp)
 
-        deflection_x = (
-            x1 * ((x1**2 - e_hk24**2) * (1 - e_hk24**2) + x2**2 * (1 + e_hk24**2)) * f1
-            + x1 * (x1**2 + x2**2 - e_hk24**2) * f2
-            - x2 * (x1**2 + x2**2 + e_hk24**2) * f3
+        deflection_x = prefactor * (
+            x1 * ((x1_sq - e_sq) * (1 - e_sq) + x2_sq * (1 + e_sq)) * f1
+            + x1 * (r_sq - e_sq) * f2
+            - x2 * (r_sq + e_sq) * f3
         )
-        deflection_x *= prefactor
 
-        deflection_y = (
-            x2 * (x1**2 * (1 - 2 * e_hk24**2) + x2**2 + e_hk24**2) * f1
-            + x2 * (x1**2 + x2**2 + e_hk24**2) * f2
-            + x1 * (x1**2 + x2**2 - e_hk24**2) * f3
+        deflection_y = prefactor * (
+            x2 * (x1_sq * (1 - 2 * e_sq) + x2_sq + e_sq) * f1
+            + x2 * (r_sq + e_sq) * f2
+            + x1 * (r_sq - e_sq) * f3
         )
-        deflection_y *= prefactor
 
         return xp.multiply(self.scale_radius, xp.vstack((deflection_y, deflection_x)).T)
 
@@ -396,8 +403,10 @@ class NFWSph(NFW):
         )
 
     def deflection_func_sph(self, grid_radius, xp=np):
-        grid_radius = grid_radius + 0j
-        return xp.real(self.coord_func_h(grid_radius=grid_radius, xp=xp))
+        # `coord_func_h` is real for a real radius: `coord_func_f_from` evaluates each of its
+        # branches on masked real inputs, so there is no complex promotion to take the real
+        # part of.
+        return self.coord_func_h(grid_radius=grid_radius, xp=xp)
 
     @aa.over_sample
     @aa.decorators.to_array

--- a/autogalaxy/profiles/mass/dark/nfw_hk24_util.py
+++ b/autogalaxy/profiles/mass/dark/nfw_hk24_util.py
@@ -42,6 +42,23 @@ def capital_F_from(chi, xp=np):
     less = chi < 1 - eps
     greater = chi > 1 + eps
 
+    if xp is np:
+        # Each branch is evaluated on its own subset of the grid only: the arctanh branch
+        # inside the scale radius and the arctan branch outside it never see each other's
+        # coordinates, so neither the special functions nor the square roots run twice over
+        # the whole grid, and no masked-out input reaches a function it is invalid for.
+        F = np.ones(chi.shape, dtype=np.result_type(chi, 1.0))
+
+        chi_less = chi[less]
+        root_min = np.sqrt(1.0 - chi_less**2)
+        F[less] = np.arctanh(root_min) / root_min
+
+        chi_greater = chi[greater]
+        root_plus = np.sqrt(chi_greater**2 - 1.0)
+        F[greater] = np.arctan(root_plus) / root_plus
+
+        return F
+
     root_min_arg = xp.where(less, 1 - chi**2, 0.0)
     root_min = xp.sqrt(root_min_arg)
     root_min_safe = xp.where(less, root_min, 1.0)

--- a/autogalaxy/profiles/mass/total/isothermal.py
+++ b/autogalaxy/profiles/mass/total/isothermal.py
@@ -110,28 +110,20 @@ class Isothermal(PowerLaw):
             The grid of (y,x) arc-second coordinates the deflection angles are computed on.
         """
 
+        axis_ratio = self.axis_ratio(xp)
+        sqrt_one_minus_q2 = xp.sqrt(1 - axis_ratio**2)
+
         factor = (
-            2.0
-            * self.einstein_radius_rescaled(xp)
-            * self.axis_ratio(xp)
-            / xp.sqrt(1 - self.axis_ratio(xp) ** 2)
+            2.0 * self.einstein_radius_rescaled(xp) * axis_ratio / sqrt_one_minus_q2
         )
 
-        psi = psi_from(
-            grid=grid, axis_ratio=self.axis_ratio(xp), core_radius=0.0, xp=xp
-        )
+        psi = psi_from(grid=grid, axis_ratio=axis_ratio, core_radius=0.0, xp=xp)
 
         deflection_y = xp.arctanh(
-            xp.divide(
-                xp.multiply(xp.sqrt(1 - self.axis_ratio(xp) ** 2), grid.array[:, 0]),
-                psi,
-            )
+            xp.divide(xp.multiply(sqrt_one_minus_q2, grid.array[:, 0]), psi)
         )
         deflection_x = xp.arctan(
-            xp.divide(
-                xp.multiply(xp.sqrt(1 - self.axis_ratio(xp) ** 2), grid.array[:, 1]),
-                psi,
-            )
+            xp.divide(xp.multiply(sqrt_one_minus_q2, grid.array[:, 1]), psi)
         )
         return xp.multiply(factor, xp.vstack((deflection_y, deflection_x)).T)
 

--- a/autogalaxy/profiles/mass/total/power_law.py
+++ b/autogalaxy/profiles/mass/total/power_law.py
@@ -1,9 +1,88 @@
+import math
 import numpy as np
 from typing import Tuple
 
 import autoarray as aa
 
 from autogalaxy.profiles.mass.total.power_law_core import PowerLawCore
+
+# Relative truncation error of the numpy omega series, as a bound on the geometric tail
+# sum_{n >= N} f^n = f^N / (1 - f) with f the second flattening (1 - q) / (1 + q). Two orders
+# of magnitude tighter than the rtol 1e-6 the deflection pins are checked at, so the series
+# is at least as accurate as the complex `hyp2f1` it replaces on every physical axis ratio.
+_OMEGA_SERIES_RTOL = 1e-10
+
+
+def _omega_n_terms_from(factor: float, rtol: float = _OMEGA_SERIES_RTOL) -> int:
+    """
+    The number of terms of the Tessore & Metcalf (2015, eq. 29) omega series needed for its
+    truncation error to be below `rtol`, as a plain Python int.
+
+    Every term of the recurrence is bounded by `factor ** n` in magnitude (the ratio
+    `(2n - (2 - t)) / (2n + (2 - t))` is below one for all slopes `t` in (0, 2)), so the tail
+    after `N` terms is at most `factor ** N / (1 - factor)`; the smallest `N` with that bound
+    below `rtol` is returned. The count follows the axis ratio: 11 terms at q = 0.8, 39 at
+    q = 0.3, 124 at q = 0.1 (rtol 1e-10). A fixed count fails for q below ~0.25, the recorded
+    hazard `component.power-law.series-vs-hyp2f1-divergence`.
+
+    Parameters
+    ----------
+    factor
+        The second flattening `f = (1 - q) / (1 + q)` of the ellipse with axis ratio `q`.
+    rtol
+        The bound on the relative truncation error of the series.
+    """
+    factor = float(factor)
+    if factor <= 0.0:
+        return 1
+    if factor >= 1.0:
+        raise ValueError(
+            f"The power-law omega series does not converge for factor={factor} "
+            f"(axis_ratio must be > 0)."
+        )
+    return max(2, math.ceil((math.log(rtol) + math.log1p(-factor)) / math.log(factor)))
+
+
+def _omega_series_from(z: np.ndarray, slope: float, factor: float, n_terms: int) -> np.ndarray:
+    """
+    Numpy evaluation of the angular part of the elliptical power-law deflection, the omega
+    series of Tessore & Metcalf (2015, eq. 29) truncated after `n_terms` terms. The same
+    recurrence `jax_utils.omega` evaluates with `jax.lax.scan` on the JAX path, written as a
+    polynomial in `w = -factor * z ** 2` with real coefficients
+
+        omega = z * sum_n a_n w ** n,   a_0 = 1,   a_n = a_{n-1} (2n - (2 - t)) / (2n + (2 - t))
+
+    and evaluated by Horner's rule, which is one complex multiply-add per term over the grid.
+
+    Parameters
+    ----------
+    z
+        `exp(i * phi)` where `phi` is the elliptical angle of every coordinate on the grid.
+    slope
+        The internal power-law slope `t = slope - 1`.
+    factor
+        The second flattening `f = (1 - q) / (1 + q)`.
+    n_terms
+        The number of terms of the series to sum (see `_omega_n_terms_from`).
+    """
+    two_minus_slope = 2.0 - slope
+
+    coefficients = np.empty(n_terms)
+    coefficients[0] = 1.0
+    for n in range(1, n_terms):
+        two_n = 2.0 * n
+        coefficients[n] = (
+            coefficients[n - 1] * (two_n - two_minus_slope) / (two_n + two_minus_slope)
+        )
+
+    w = -factor * z * z
+
+    polynomial = np.full(z.shape, coefficients[-1], dtype=np.complex128)
+    for coefficient in coefficients[-2::-1]:
+        polynomial *= w
+        polynomial += coefficient
+
+    return z * polynomial
 
 
 class PowerLaw(PowerLawCore):
@@ -101,56 +180,56 @@ class PowerLaw(PowerLawCore):
             The grid of (y,x) arc-second coordinates the deflection angles are computed on.
         """
         slope = self.slope - 1.0
+        axis_ratio = self.axis_ratio(xp)
+
         einstein_radius = (
-            2.0 / (self.axis_ratio(xp) ** -0.5 + self.axis_ratio(xp) ** 0.5)
+            2.0 / (axis_ratio**-0.5 + axis_ratio**0.5)
         ) * self.einstein_radius_major_from(xp)
 
-        factor = xp.divide(1.0 - self.axis_ratio(xp), 1.0 + self.axis_ratio(xp))
-        b = xp.multiply(einstein_radius, xp.sqrt(self.axis_ratio(xp)))
-        angle = xp.arctan2(
-            grid.array[:, 0], xp.multiply(self.axis_ratio(xp), grid.array[:, 1])
-        )  # Note, this angle is not the position angle
-        z = xp.add(
-            xp.multiply(xp.cos(angle), 1 + 0j), xp.multiply(xp.sin(angle), 0 + 1j)
-        )
+        factor = (1.0 - axis_ratio) / (1.0 + axis_ratio)
+        b = einstein_radius * xp.sqrt(axis_ratio)
 
-        R = xp.sqrt(
-            (self.axis_ratio(xp) * grid.array[:, 1]) ** 2
-            + grid.array[:, 0] ** 2
-            + 1e-16
-        )
+        y = grid.array[:, 0]
+        qx = axis_ratio * grid.array[:, 1]
+
+        R = xp.sqrt(qx**2 + y**2 + 1e-16)
 
         if xp.__name__.startswith("jax"):
 
             from .jax_utils import omega
 
+            angle = xp.arctan2(y, qx)  # Note, this angle is not the position angle
+            z = xp.add(
+                xp.multiply(xp.cos(angle), 1 + 0j), xp.multiply(xp.sin(angle), 0 + 1j)
+            )
+
             zh = omega(z, slope, factor, n_terms=20, xp=xp)
 
-            complex_angle = (
-                2.0 * b / (1.0 + self.axis_ratio(xp)) * (b / R) ** (slope - 1.0) * zh
-            )
         else:
 
-            from scipy import special
+            # `z = exp(i * angle)` is the unit vector (q x + i y) / |q x + i y|, formed without
+            # the per-coordinate arctan2, cos and sin; the exact centre, where that vector has
+            # no direction, takes z = 1 as arctan2(0, 0) = 0 did.
+            r_ell = np.hypot(qx, y)
+            on_centre = r_ell == 0.0
+            z = (qx + 1j * y) / np.where(on_centre, 1.0, r_ell)
+            z = np.where(on_centre, 1.0 + 0j, z)
 
-            complex_angle = (
-                2.0
-                * b
-                / (1.0 + self.axis_ratio(xp))
-                * (b / R) ** (slope - 1.0)
-                * z
-                * special.hyp2f1(1.0, 0.5 * slope, 2.0 - 0.5 * slope, -factor * z**2)
+            zh = _omega_series_from(
+                z, slope, factor, n_terms=_omega_n_terms_from(factor)
             )
 
-        deflection_y = complex_angle.imag
-        deflection_x = complex_angle.real
+        prefactor = (
+            2.0
+            * b
+            / (1.0 + axis_ratio)
+            * self.ellipticity_rescale(xp) ** (slope - 1.0)
+            * (b / R) ** (slope - 1.0)
+        )
 
-        rescale_factor = (self.ellipticity_rescale(xp)) ** (slope - 1)
+        complex_angle = prefactor * zh
 
-        deflection_y *= rescale_factor
-        deflection_x *= rescale_factor
-
-        return xp.vstack((deflection_y, deflection_x)).T
+        return xp.vstack((complex_angle.imag, complex_angle.real)).T
 
     def convergence_func(self, grid_radius: float, xp=np) -> float:
         return self.einstein_radius_rescaled(xp) * grid_radius.array ** (


### PR DESCRIPTION
## Summary
Closes #598 — phase 3 of the `numpy-deflections-cpu` epic: the closed-form mass profiles on the numpy (`xp=np`) path.

- **PowerLaw** — the numpy branch of `deflections_yx_2d_from` evaluates the Tessore & Metcalf (2015, eq. 29) omega series (the recurrence `jax_utils.omega` already runs on JAX) in Horner form with real coefficients, instead of scipy's complex `hyp2f1`. **The term count follows the second flattening** `f = (1 − q)/(1 + q)` through the geometric tail bound `f^N/(1 − f) ≤ 1e-10`: 11 terms at q = 0.8, 39 at q = 0.3, 124 at q = 0.1, 254 at q = 0.05 (a fixed 20 fails below q ≈ 0.25, the recorded hazard `component.power-law.series-vs-hyp2f1-divergence`). Verified against `mpmath.hyp2f1` (40 digits) over slope 1.5–2.99 × q 0.05–0.99: worst relative error 5.7e-11. `axis_ratio` is derived once (was 11× per call); `z = exp(iφ)` is formed as the unit vector `(q x + i y)/|q x + i y|` with the exact centre kept at `z = 1`; the rescale factor is folded into the scalar prefactor (no in-place multiply on a view of the complex field). On a 15k-point grid the series costs 0.21 ms where `hyp2f1` cost 7.4 ms at q = 0.8, and 2.1 ms vs 49 ms at q = 0.1 — so no `hyp2f1` fallback is kept. **The JAX branch and its 20-term default are untouched.**
- **NFW** — `capital_F_from` evaluates its arctanh and arctan branches on their own subsets of the grid on numpy (JAX keeps the `where` cascade); the HK24 analytic deflection masks the centre point's *inputs* to a point on the unit ellipse before anything is evaluated and zeroes it through the prefactor, so no branch runs on a zero radius — the three `RuntimeWarning`s per call are gone without `errstate`; repeated squares hoisted.
- **NFWSph** — `coord_func_f_from` evaluates each branch on inputs masked into its domain and keeps the input dtype, so the spherical deflection is real arithmetic end to end instead of `complex128` promoted from a `complex64` ones-array; `coord_func_g` masks its denominators the same way (its r = 1 division warning is gone too).
- **Isothermal** — `axis_ratio` and `sqrt(1 − q²)` evaluated once per call (were ~8×).

Deflections are unchanged against `main` on the hst grid (field-level A/B): max relative difference 1.1e-8 for PowerLaw — the `hyp2f1` side's own accuracy, the series is the more accurate routine — and below 1e-9 for every other profile; every autolens_profiling pin held at rtol 1e-6. The before/after measurement of record lands in the autolens_profiling PR of this phase; the shared-geometry half is PyAutoArray#519.

## API Changes
No public API change. Two private module helpers (`_omega_n_terms_from`, `_omega_series_from`) in `total/power_law.py`. `coord_func_f_from` now returns a real array for a real input (it returned `complex128` via a `complex64` promotion); complex inputs are unchanged.
See full details below.

## Test Plan
- [x] `test_autogalaxy` — 1151 passed, 1 skipped (`-n 4`); `test_power_law`, `test_isothermal`, `test_nfw`, `test_gnfw`, `test_abstract`, `test_nfw_truncated`, `test_transform_rotate_back` also run with `-W error::RuntimeWarning`
- [x] Series vs `mpmath.hyp2f1` over slope 1.5–2.99 × q 0.05–0.99: worst 5.7e-11 relative
- [x] Field-level A/B vs `main`, hst grid, 10 profile configurations (incl. q = 0.3 / q = 1 PowerLaw, r_s = 1" NFW/NFWSph, gNFW, NFWTruncatedSph): ≤ 1.1e-8 relative
- [x] `ruff check` / `ruff format --check` — no new findings; format state of each changed file identical to `main`
- [x] autolens_profiling deflection pins (hst + euclid, all nine profiles) held at rtol 1e-6; `pixelization_numba` hst likelihood pin 27661.910133665442 PASSED

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- none

### Added
- `autogalaxy.profiles.mass.total.power_law._omega_n_terms_from(factor, rtol=1e-10)` — private; term count from the geometric tail bound
- `autogalaxy.profiles.mass.total.power_law._omega_series_from(z, slope, factor, n_terms)` — private; Horner evaluation of the omega series on numpy

### Changed
- `PowerLaw.deflections_yx_2d_from` — numpy branch uses the omega series (rtol 1e-10) instead of `scipy.special.hyp2f1`; JAX branch unchanged
- `dark.abstract.coord_func_f_from(grid_radius, xp)` — result dtype follows the input (real → real); values unchanged
- `dark.nfw_hk24_util.capital_F_from(chi, xp)` — numpy evaluates each branch on its own subset; values unchanged
- `NFW.deflections_2d_via_analytic_from`, `NFWSph.deflection_func_sph`, `Isothermal.deflections_yx_2d_from`, `AbstractgNFW.coord_func_g` — same results, no `RuntimeWarning`s

### Migration
- none required

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Re4JLhTCFnGYeez8oEyM6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Re4JLhTCFnGYeez8oEyM6M)_