### PR TITLE
perf: memoise fixed-geometry deflections, rescale Gaussians by mass_to_light_ratio (numpy) (#601)

### DIFF
--- a/autogalaxy/galaxy/galaxy.py
+++ b/autogalaxy/galaxy/galaxy.py
@@ -26,6 +26,7 @@ from autogalaxy.profiles.geometry_profiles import GeometryProfile
 from autogalaxy.profiles.light.abstract import LightProfile
 from autogalaxy.profiles.light.linear import LightProfileLinear
 from autogalaxy.profiles.light.snr.abstract import LightProfileSNR
+from autogalaxy.profiles.mass.abstract import deflections_memo
 from autogalaxy.profiles.mass.abstract.abstract import MassProfile
 from autogalaxy.profiles import validate
 
@@ -298,9 +299,13 @@ class Galaxy(af.ModelObject, OperateImageList):
             The 2D (y, x) coordinates where values of the deflection angles are evaluated.
         """
         if self.has(cls=MassProfile):
+            # Routed through `deflections_memo` (not called directly) so a fixed-geometry
+            # profile's field is reused across likelihood evaluations; the helper falls
+            # through to `p.deflections_yx_2d_from` whenever it cannot key the call
+            # exactly, and is a no-op on the JAX path.
             return sum(
                 map(
-                    lambda p: p.deflections_yx_2d_from(grid=grid, xp=xp),
+                    lambda p: deflections_memo.deflections_yx_2d_from(p, grid, xp),
                     self.cls_list_from(cls=MassProfile),
                 )
             )

--- a/autogalaxy/profiles/basis.py
+++ b/autogalaxy/profiles/basis.py
@@ -16,6 +16,7 @@ from typing import Dict, List, Optional, Union
 import autoarray as aa
 
 from autogalaxy.profiles.light.abstract import LightProfile
+from autogalaxy.profiles.mass.abstract import deflections_memo
 from autogalaxy.profiles.mass.abstract.abstract import MassProfile
 
 from autogalaxy.profiles.light import linear as lp_linear
@@ -243,9 +244,14 @@ class Basis(LightProfile, MassProfile):
         The deflections of the mass profiles in the basis summed together.
         """
         if len(self.mass_profile_list) > 0:
+            # Routed through `deflections_memo` (not called directly) so each fixed
+            # Gaussian's field is computed once and rescaled by its
+            # `mass_to_light_ratio` on later evaluations; the helper falls through to
+            # `mass.deflections_yx_2d_from` whenever it cannot key the call exactly, and
+            # is a no-op on the JAX path.
             return sum(
                 [
-                    mass.deflections_yx_2d_from(grid=grid, xp=xp)
+                    deflections_memo.deflections_yx_2d_from(mass, grid, xp)
                     for mass in self.profile_list
                 ]
             )

--- a/autogalaxy/profiles/mass/abstract/deflections_memo.py
+++ b/autogalaxy/profiles/mass/abstract/deflections_memo.py
@@ -1,0 +1,480 @@
+"""
+Cross-evaluation memo for mass-profile deflection angles on the numpy path.
+
+In the SLaM ``mass_light_dark`` stage every Gaussian of an MGE lens light is fixed --
+centre, ``ell_comps``, ``sigma`` and ``intensity`` come from the light-stage instance --
+and the whole stack shares one free ``mass_to_light_ratio``. A sampler nevertheless
+builds fresh profile objects for every likelihood evaluation, so the identical Faddeeva
+field is recomputed each call. This module memoises that field.
+
+Two levers, both keyed on parameter *values* (never on model metadata, which never
+reaches profile code):
+
+- **L1** -- any mass profile whose constructor arguments are all scalars: the final
+  (y,x) deflection field is stored for that (profile, grid) pair and returned on a hit.
+- **L2** -- ``mp.Gaussian`` and the ``lmp`` / ``lmp_linear`` Gaussians that inherit its
+  deflections: the key excludes ``mass_to_light_ratio`` and the stored field is the
+  **unit-ratio** field, evaluated through the normal path on a copy of the profile whose
+  ``mass_to_light_ratio`` is ``1.0``; a hit (and the miss that filled it) returns
+  ``mass_to_light_ratio x field``. The deflection is exactly linear in that scalar, so
+  the only difference from a direct call is the order of one multiplication -- a
+  relative difference at the ulp level, orders of magnitude inside the 1e-12 tolerance
+  the unit tests hold it to. ``GaussianGradient`` is *not* linear in a single scalar and
+  takes L1 only.
+
+Grids are keyed by **content**, not identity: ``FitDataset.grids`` rebuilds the grid on
+every likelihood call, so ``id(grid)`` would miss every time. A shifted, rotated or
+re-masked grid changes the bytes and therefore misses, which is correct by construction.
+
+Failure modes are **misses, never stale hits**: anything that cannot be fingerprinted
+exactly (a non-scalar constructor argument, a JAX tracer, a grid without a numpy array)
+falls through to the ordinary call. The memo engages only when ``xp is np``; the JAX path
+is untouched.
+
+Disable with ``AUTOGALAXY_DEFLECTIONS_MEMO=0``, or in-process with the
+``memo_disabled()`` context manager (which a profiling harness needs, since it must be
+able to guarantee it restored the previous state). The byte cap defaults to 256 MB and is
+overridden with ``AUTOGALAXY_DEFLECTIONS_MEMO_MAX_MB`` (over-sampled grids are large, so
+the cap is on bytes, not on the number of entries; eviction is FIFO).
+"""
+
+import contextlib
+import copy
+import hashlib
+import inspect
+import os
+import weakref
+
+import numpy as np
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+
+from autoarray.structures.decorators.to_vector_yx import VectorYXMaker
+
+
+class MemoEntry(NamedTuple):
+    """
+    One memoised deflection field.
+
+    Parameters
+    ----------
+    field
+        The stored (y,x) deflection angles, read-only. For an L2 entry this is the
+        unit-``mass_to_light_ratio`` field; for an L1 entry it is the field itself.
+    wrapped
+        Whether the direct call returned a structure (``VectorYX2D`` /
+        ``VectorYX2DIrregular``) rather than a bare ndarray, so a hit reproduces the
+        same type.
+    """
+
+    field: np.ndarray
+    wrapped: bool
+
+
+_deflections_memo: Dict[str, MemoEntry] = {}
+
+_DEFAULT_MAX_MB = 256.0
+
+_stats = {"hits": 0, "misses": 0, "evictions": 0, "bytes": 0}
+
+# id(grid) -> (weakref to the grid, its fingerprint). One likelihood evaluation calls
+# this module once per mass profile with the *same* grid object, so hashing the grid
+# bytes per profile would dominate the hit path (~0.2 ms x 30 Gaussians). The weakref
+# makes a recycled id a miss rather than a wrong answer. It does assume the grid's
+# coordinate array is not mutated in place after it is first fingerprinted, which no
+# library path does -- grids are rebuilt, never edited.
+_grid_fingerprint_cache: Dict[int, Tuple[Any, str]] = {}
+
+_GRID_FINGERPRINT_CACHE_MAX_ENTRIES = 8
+
+# type -> the names of its constructor arguments, or None if it has none that can be
+# read back (``*args`` / ``**kwargs``, or an unreadable signature).
+_init_argument_names: Dict[type, Optional[Tuple[str, ...]]] = {}
+
+_gaussian_classes: Optional[Tuple[type, type]] = None
+
+# Set by `memo_disabled()`, which overrides the env switch for the duration of a block.
+# A caller that must measure the *uncached* per-call cost of a deflection cannot use the
+# env var: this module reads it at call time, but a profiling harness needs a scope it
+# can guarantee it restored.
+_suspended = False
+
+
+@contextlib.contextmanager
+def memo_disabled():
+    """
+    Suspend the memo for the duration of the block, whatever the env switch says.
+
+    Restores the previous state on exit, including on an exception. Nesting is safe.
+    """
+    global _suspended
+
+    previous = _suspended
+    _suspended = True
+    try:
+        yield
+    finally:
+        _suspended = previous
+
+
+def memo_enabled() -> bool:
+    """
+    Whether the deflection memo is active in this process.
+    """
+    if _suspended:
+        return False
+
+    return os.environ.get("AUTOGALAXY_DEFLECTIONS_MEMO", "1") != "0"
+
+
+def memo_max_bytes() -> int:
+    """
+    The memo's byte cap, from ``AUTOGALAXY_DEFLECTIONS_MEMO_MAX_MB`` (default 256 MB).
+
+    An unparseable value falls back to the default rather than raising: a bad env var
+    must not break a fit.
+    """
+    try:
+        max_mb = float(
+            os.environ.get("AUTOGALAXY_DEFLECTIONS_MEMO_MAX_MB", _DEFAULT_MAX_MB)
+        )
+    except (TypeError, ValueError):
+        max_mb = _DEFAULT_MAX_MB
+
+    return int(max(max_mb, 0.0) * 1024 * 1024)
+
+
+def memo_stats() -> Dict[str, int]:
+    """
+    The memo's counters: ``hits``, ``misses``, ``evictions``, ``bytes`` stored and the
+    number of ``entries``.
+    """
+    return {
+        "hits": _stats["hits"],
+        "misses": _stats["misses"],
+        "evictions": _stats["evictions"],
+        "bytes": _stats["bytes"],
+        "entries": len(_deflections_memo),
+    }
+
+
+def memo_clear() -> None:
+    """
+    Empty the memo and reset its counters.
+    """
+    _deflections_memo.clear()
+    _grid_fingerprint_cache.clear()
+    _stats.update({"hits": 0, "misses": 0, "evictions": 0, "bytes": 0})
+
+
+def _scalar_token(value) -> Optional[str]:
+    """
+    An exact, hashable token for a constructor-argument value, or None if the value is
+    not a scalar (or a tuple / list of scalars) and the profile is therefore not
+    memoisable.
+
+    ``repr`` of a Python float round-trips exactly, so the token distinguishes any two
+    values the deflection calculation would distinguish. A JAX tracer, an ndarray or a
+    nested object all return None, which is what keeps the memo off those profiles.
+    """
+    if value is None or isinstance(value, (bool, str)):
+        return repr(value)
+
+    if isinstance(value, (int, float)):
+        return f"{type(value).__name__}:{value!r}"
+
+    if isinstance(value, np.generic):
+        return f"np:{value.dtype.str}:{value.item()!r}"
+
+    if isinstance(value, (tuple, list)):
+        tokens = [_scalar_token(item) for item in value]
+        if any(token is None for token in tokens):
+            return None
+        return f"{type(value).__name__}({','.join(tokens)})"
+
+    return None
+
+
+def _init_argument_names_from(cls: type) -> Optional[Tuple[str, ...]]:
+    """
+    The names of ``cls.__init__``'s arguments, cached per class.
+
+    Returns None -- meaning "not memoisable" -- for a constructor taking ``*args`` or
+    ``**kwargs``, since an argument that is not a named parameter cannot be read back
+    off the instance and a value that is not in the key can silently change the answer.
+    """
+    if cls in _init_argument_names:
+        return _init_argument_names[cls]
+
+    try:
+        signature = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):
+        _init_argument_names[cls] = None
+        return None
+
+    names: List[str] = []
+
+    for name, parameter in signature.parameters.items():
+        if name == "self":
+            continue
+        if parameter.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            _init_argument_names[cls] = None
+            return None
+        names.append(name)
+
+    _init_argument_names[cls] = tuple(names)
+    return _init_argument_names[cls]
+
+
+def _profile_token(profile, skip: Tuple[str, ...] = ()) -> Optional[str]:
+    """
+    An exact token for a profile's identity: its class plus the values of its
+    constructor arguments, read off the instance and excluding the names in ``skip``.
+
+    Returns None if any argument is missing from the instance or is not a scalar, in
+    which case the profile is not memoisable. Only constructor arguments are read, so a
+    cached array a profile builds on its first call cannot turn a memoisable profile
+    into an unmemoisable one halfway through a run.
+    """
+    cls = type(profile)
+
+    names = _init_argument_names_from(cls)
+
+    if names is None:
+        return None
+
+    attributes = vars(profile)
+
+    tokens = [f"{cls.__module__}.{cls.__qualname__}"]
+
+    for name in names:
+        if name in skip:
+            continue
+        if name not in attributes:
+            return None
+        token = _scalar_token(attributes[name])
+        if token is None:
+            return None
+        tokens.append(f"{name}={token}")
+
+    return "|".join(tokens)
+
+
+def _grid_fingerprint(grid) -> Optional[str]:
+    """
+    A content fingerprint of ``grid``: the sha256 of its coordinate bytes, its type name,
+    shape and dtype, and its ``pixel_scales`` / ``origin`` where the type has them.
+
+    Returns None if the grid carries no numpy coordinate array (a JAX-backed grid, say),
+    which makes the profile unmemoisable rather than wrongly memoised.
+    """
+    values = getattr(grid, "array", grid)
+
+    if not isinstance(values, np.ndarray):
+        return None
+
+    cached = _grid_fingerprint_cache.get(id(grid))
+
+    if cached is not None and cached[0]() is grid:
+        return cached[1]
+
+    values = np.ascontiguousarray(values)
+
+    digest = hashlib.sha256()
+    digest.update(type(grid).__name__.encode())
+    digest.update(f"{values.shape}:{values.dtype.str}".encode())
+
+    for name in ("pixel_scales", "origin"):
+        try:
+            digest.update(f"{name}={getattr(grid, name, None)!r}".encode())
+        except Exception:
+            digest.update(f"{name}=<unavailable>".encode())
+
+    digest.update(values.tobytes())
+
+    fingerprint = digest.hexdigest()
+
+    try:
+        reference = weakref.ref(grid)
+    except TypeError:
+        return fingerprint
+
+    if len(_grid_fingerprint_cache) >= _GRID_FINGERPRINT_CACHE_MAX_ENTRIES:
+        dead = [
+            key for key, entry in _grid_fingerprint_cache.items() if entry[0]() is None
+        ]
+        for key in dead or [next(iter(_grid_fingerprint_cache))]:
+            _grid_fingerprint_cache.pop(key, None)
+
+    _grid_fingerprint_cache[id(grid)] = (reference, fingerprint)
+
+    return fingerprint
+
+
+def _memo_key(tier: str, profile_token: str, grid_fingerprint: str) -> str:
+    return hashlib.sha256(
+        f"{tier}|{profile_token}|{grid_fingerprint}".encode()
+    ).hexdigest()
+
+
+def _gaussian_class_pair() -> Tuple[type, type]:
+    """
+    ``(Gaussian, GaussianGradient)``, imported lazily so this module stays importable
+    from anywhere in the profile package without a circular import.
+    """
+    global _gaussian_classes
+
+    if _gaussian_classes is None:
+        from autogalaxy.profiles.mass.stellar.gaussian import Gaussian
+        from autogalaxy.profiles.mass.stellar.gaussian_gradient import GaussianGradient
+
+        _gaussian_classes = (Gaussian, GaussianGradient)
+
+    return _gaussian_classes
+
+
+def _takes_ratio_split(profile) -> bool:
+    """
+    Whether ``profile`` takes the L2 (unit-ratio) split: a ``Gaussian`` mass profile
+    whose deflections are exactly linear in ``mass_to_light_ratio``.
+
+    ``GaussianGradient`` subclasses ``Gaussian`` but derives its ratio from three
+    parameters, so it is excluded and takes L1.
+    """
+    gaussian, gaussian_gradient = _gaussian_class_pair()
+
+    if not isinstance(profile, gaussian) or isinstance(profile, gaussian_gradient):
+        return False
+
+    return isinstance(getattr(profile, "mass_to_light_ratio", None), (int, float))
+
+
+def _unwrap(result) -> Tuple[Optional[np.ndarray], bool]:
+    """
+    The numpy array inside a deflection result, and whether it arrived inside a
+    structure (``VectorYX2D`` / ``VectorYX2DIrregular``) rather than bare.
+
+    Returns ``(None, False)`` for anything else, which is not stored.
+    """
+    array = getattr(result, "array", None)
+
+    if isinstance(array, np.ndarray):
+        return array, True
+
+    if isinstance(result, np.ndarray):
+        return result, False
+
+    return None, False
+
+
+def _store(key: str, field: np.ndarray, wrapped: bool) -> None:
+    """
+    Store a read-only copy of ``field``, evicting the oldest entries (FIFO) until the
+    memo fits its byte cap. A field larger than the whole cap is not stored at all.
+    """
+    stored = np.array(field)
+    stored.setflags(write=False)
+
+    max_bytes = memo_max_bytes()
+
+    if stored.nbytes > max_bytes:
+        return
+
+    while _deflections_memo and _stats["bytes"] + stored.nbytes > max_bytes:
+        evicted = _deflections_memo.pop(next(iter(_deflections_memo)))
+        _stats["bytes"] -= evicted.field.nbytes
+        _stats["evictions"] += 1
+
+    _deflections_memo[key] = MemoEntry(field=stored, wrapped=wrapped)
+    _stats["bytes"] += stored.nbytes
+
+
+def _wrapped_result(field: np.ndarray, grid, xp, wrapped: bool):
+    """
+    ``field`` returned in the shape a direct call would have returned it: re-wrapped for
+    ``grid`` by the same maker the ``to_vector_yx`` decorator uses, or bare if the direct
+    call was bare.
+    """
+    if not wrapped:
+        return field
+
+    return VectorYXMaker(
+        func=lambda _obj, _grid, _xp, **kwargs: field, obj=None, grid=grid, xp=xp
+    ).result
+
+
+def deflections_yx_2d_from(profile, grid, xp=np):
+    """
+    The deflection angles of ``profile`` on ``grid``, from the memo where the profile's
+    parameter values and the grid's contents are both unchanged from a previous call,
+    and from ``profile.deflections_yx_2d_from`` otherwise.
+
+    This is the single intercept the summation call sites (``Galaxy`` and ``Basis``) go
+    through, so no mass profile needs an override of its own.
+
+    Parameters
+    ----------
+    profile
+        The mass profile whose deflection angles are computed.
+    grid
+        The 2D (y,x) coordinates the deflection angles are computed on.
+    xp
+        The array backend. The memo engages only for numpy; JAX falls straight through.
+    """
+
+    def direct():
+        return profile.deflections_yx_2d_from(grid=grid, xp=xp)
+
+    if xp is not np or not memo_enabled():
+        return direct()
+
+    ratio_split = _takes_ratio_split(profile)
+
+    profile_token = _profile_token(
+        profile, skip=("mass_to_light_ratio",) if ratio_split else ()
+    )
+
+    if profile_token is None:
+        return direct()
+
+    grid_fingerprint = _grid_fingerprint(grid)
+
+    if grid_fingerprint is None:
+        return direct()
+
+    tier = "L2" if ratio_split else "L1"
+
+    key = _memo_key(tier, profile_token, grid_fingerprint)
+
+    entry = _deflections_memo.get(key)
+
+    if entry is not None:
+        _stats["hits"] += 1
+        if ratio_split:
+            return _wrapped_result(
+                profile.mass_to_light_ratio * entry.field, grid, xp, entry.wrapped
+            )
+        return _wrapped_result(np.array(entry.field), grid, xp, entry.wrapped)
+
+    _stats["misses"] += 1
+
+    if ratio_split:
+        unit_profile = copy.copy(profile)
+        unit_profile.mass_to_light_ratio = 1.0
+        result = unit_profile.deflections_yx_2d_from(grid=grid, xp=xp)
+    else:
+        result = direct()
+
+    field, wrapped = _unwrap(result)
+
+    if field is None:
+        return result
+
+    _store(key, field, wrapped)
+
+    if ratio_split:
+        return _wrapped_result(profile.mass_to_light_ratio * field, grid, xp, wrapped)
+
+    return result

--- a/test_autogalaxy/profiles/mass/abstract/test_deflections_memo.py
+++ b/test_autogalaxy/profiles/mass/abstract/test_deflections_memo.py
@@ -1,0 +1,348 @@
+import numpy as np
+import pytest
+
+import autogalaxy as ag
+
+from autogalaxy.profiles.mass.abstract import deflections_memo
+
+
+@pytest.fixture(autouse=True)
+def clear_memo():
+    deflections_memo.memo_clear()
+    yield
+    deflections_memo.memo_clear()
+
+
+def grid_2d(origin=(0.0, 0.0)):
+    return ag.Grid2D.uniform(
+        shape_native=(12, 12), pixel_scales=0.2, origin=origin, over_sample_size=1
+    )
+
+
+def gaussian(mass_to_light_ratio=2.0):
+    return ag.mp.Gaussian(
+        centre=(0.05, -0.05),
+        ell_comps=(0.1, 0.15),
+        intensity=1.3,
+        sigma=0.9,
+        mass_to_light_ratio=mass_to_light_ratio,
+    )
+
+
+def values(result):
+    return np.asarray(getattr(result, "array", result), dtype=float)
+
+
+def test__repeated_call_with_same_values_hits__different_values_misses():
+    grid = grid_2d()
+    profile = ag.mp.Isothermal(
+        centre=(0.0, 0.0), ell_comps=(0.1, 0.1), einstein_radius=1.2
+    )
+
+    deflections_memo.deflections_yx_2d_from(profile, grid, np)
+    assert deflections_memo.memo_stats()["misses"] == 1
+    assert deflections_memo.memo_stats()["hits"] == 0
+
+    deflections_memo.deflections_yx_2d_from(profile, grid, np)
+    assert deflections_memo.memo_stats()["hits"] == 1
+
+    # An identically parameterised *new* object hits: the key is values, not identity.
+    same = ag.mp.Isothermal(
+        centre=(0.0, 0.0), ell_comps=(0.1, 0.1), einstein_radius=1.2
+    )
+    deflections_memo.deflections_yx_2d_from(same, grid, np)
+    assert deflections_memo.memo_stats()["hits"] == 2
+
+    moved = ag.mp.Isothermal(
+        centre=(0.0, 0.0), ell_comps=(0.1, 0.1), einstein_radius=1.3
+    )
+    deflections_memo.deflections_yx_2d_from(moved, grid, np)
+    assert deflections_memo.memo_stats()["misses"] == 2
+
+
+def test__l1_hit_returns_the_same_type_and_content_as_the_direct_call():
+    grid = grid_2d()
+    profile = ag.mp.Isothermal(
+        centre=(0.0, 0.0), ell_comps=(0.1, 0.1), einstein_radius=1.2
+    )
+
+    direct = profile.deflections_yx_2d_from(grid=grid)
+
+    deflections_memo.deflections_yx_2d_from(profile, grid, np)
+    hit = deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    assert type(hit) is type(direct)
+    assert values(hit) == pytest.approx(values(direct), rel=1e-12, abs=0.0)
+
+
+@pytest.mark.parametrize("ratio", [0.5, 3.0])
+def test__l2_gaussian_rescale_is_exact_against_the_direct_call(ratio):
+    grid = grid_2d()
+
+    # Fill the memo at one ratio, then hit it at another: the stored field is the
+    # unit-ratio field, so the second call is a rescale, not a recomputation.
+    deflections_memo.deflections_yx_2d_from(gaussian(mass_to_light_ratio=1.7), grid, np)
+
+    profile = gaussian(mass_to_light_ratio=ratio)
+    hit = deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    assert deflections_memo.memo_stats()["hits"] == 1
+    assert deflections_memo.memo_stats()["misses"] == 1
+
+    direct = profile.deflections_yx_2d_from(grid=grid)
+
+    assert type(hit) is type(direct)
+    assert values(hit) == pytest.approx(values(direct), rel=1e-12, abs=0.0)
+
+
+def test__l2_applies_to_the_light_and_mass_gaussian_too():
+    grid = grid_2d()
+
+    def lmp_gaussian(mass_to_light_ratio):
+        return ag.lmp.Gaussian(
+            centre=(0.05, -0.05),
+            ell_comps=(0.1, 0.15),
+            intensity=1.3,
+            sigma=0.9,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+    deflections_memo.deflections_yx_2d_from(lmp_gaussian(1.0), grid, np)
+
+    profile = lmp_gaussian(4.5)
+    hit = deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    assert deflections_memo.memo_stats()["hits"] == 1
+
+    direct = profile.deflections_yx_2d_from(grid=grid)
+
+    assert values(hit) == pytest.approx(values(direct), rel=1e-12, abs=0.0)
+
+
+def test__gaussian_gradient_takes_l1_only():
+    grid = grid_2d()
+
+    def gradient(mass_to_light_gradient):
+        return ag.mp.GaussianGradient(
+            centre=(0.05, -0.05),
+            ell_comps=(0.1, 0.15),
+            intensity=1.3,
+            sigma=0.9,
+            mass_to_light_ratio_base=1.5,
+            mass_to_light_gradient=mass_to_light_gradient,
+            mass_to_light_radius=1.0,
+        )
+
+    deflections_memo.deflections_yx_2d_from(gradient(0.5), grid, np)
+    deflections_memo.deflections_yx_2d_from(gradient(0.5), grid, np)
+
+    stats = deflections_memo.memo_stats()
+    assert (stats["hits"], stats["misses"], stats["entries"]) == (1, 1, 1)
+
+    # An L2 profile would key past the ratio; the gradient must not, so a changed
+    # gradient (which changes only the derived mass_to_light_ratio) is a miss.
+    profile = gradient(1.5)
+    result = deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    assert deflections_memo.memo_stats()["misses"] == 2
+    assert values(result) == pytest.approx(
+        values(profile.deflections_yx_2d_from(grid=grid)), rel=1e-12, abs=0.0
+    )
+
+
+def test__grid_is_keyed_by_content_not_identity():
+    profile = gaussian()
+
+    deflections_memo.deflections_yx_2d_from(profile, grid_2d(), np)
+
+    # A freshly built grid with the same coordinates hits.
+    deflections_memo.deflections_yx_2d_from(profile, grid_2d(), np)
+    assert deflections_memo.memo_stats()["hits"] == 1
+
+    # A grid built at a different origin misses.
+    deflections_memo.deflections_yx_2d_from(profile, grid_2d(origin=(0.5, 0.5)), np)
+    assert deflections_memo.memo_stats()["misses"] == 2
+
+
+def test__irregular_grid_with_the_same_coordinates_does_not_collide_with_the_grid_2d():
+    profile = gaussian()
+    grid = grid_2d()
+
+    deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    irregular = ag.Grid2DIrregular(values=np.array(grid.array))
+    result = deflections_memo.deflections_yx_2d_from(profile, irregular, np)
+
+    assert deflections_memo.memo_stats()["hits"] == 0
+    assert deflections_memo.memo_stats()["misses"] == 2
+    assert type(result) is type(profile.deflections_yx_2d_from(grid=irregular))
+
+
+def test__kill_switch_disables_the_memo(monkeypatch):
+    monkeypatch.setenv("AUTOGALAXY_DEFLECTIONS_MEMO", "0")
+
+    grid = grid_2d()
+    profile = gaussian()
+
+    for _ in range(3):
+        result = deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    assert deflections_memo.memo_stats() == {
+        "hits": 0,
+        "misses": 0,
+        "evictions": 0,
+        "bytes": 0,
+        "entries": 0,
+    }
+    assert values(result) == pytest.approx(
+        values(profile.deflections_yx_2d_from(grid=grid)), rel=1e-12, abs=0.0
+    )
+
+
+def test__memo_disabled_suspends_the_memo_and_restores_it(monkeypatch):
+    grid = grid_2d()
+    profile = gaussian()
+
+    with deflections_memo.memo_disabled():
+        for _ in range(3):
+            result = deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+        assert deflections_memo.memo_stats()["entries"] == 0
+        assert values(result) == pytest.approx(
+            values(profile.deflections_yx_2d_from(grid=grid)), rel=1e-12, abs=0.0
+        )
+
+    deflections_memo.deflections_yx_2d_from(profile, grid, np)
+    deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    assert deflections_memo.memo_stats()["hits"] == 1
+
+    # Nesting is safe, and an exception still restores the previous state.
+    with pytest.raises(RuntimeError):
+        with deflections_memo.memo_disabled():
+            with deflections_memo.memo_disabled():
+                assert not deflections_memo.memo_enabled()
+            assert not deflections_memo.memo_enabled()
+            raise RuntimeError("boom")
+
+    assert deflections_memo.memo_enabled()
+
+
+def test__byte_cap_evicts_the_oldest_entry(monkeypatch):
+    grid = grid_2d()
+
+    one_field_bytes = grid.array.size * 8
+
+    # A cap of one-and-a-bit fields: the second store evicts the first.
+    monkeypatch.setenv(
+        "AUTOGALAXY_DEFLECTIONS_MEMO_MAX_MB", str(1.5 * one_field_bytes / 1024**2)
+    )
+
+    first = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=1.0)
+    second = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=2.0)
+
+    deflections_memo.deflections_yx_2d_from(first, grid, np)
+    deflections_memo.deflections_yx_2d_from(second, grid, np)
+
+    stats = deflections_memo.memo_stats()
+    assert stats["entries"] == 1
+    assert stats["evictions"] == 1
+    assert stats["bytes"] == one_field_bytes
+
+    # The evicted entry is a miss, never a wrong answer.
+    result = deflections_memo.deflections_yx_2d_from(first, grid, np)
+    assert deflections_memo.memo_stats()["misses"] == 3
+    assert values(result) == pytest.approx(
+        values(first.deflections_yx_2d_from(grid=grid)), rel=1e-12, abs=0.0
+    )
+
+
+def test__entry_larger_than_the_whole_cap_is_not_stored(monkeypatch):
+    monkeypatch.setenv("AUTOGALAXY_DEFLECTIONS_MEMO_MAX_MB", "0")
+
+    grid = grid_2d()
+    profile = gaussian()
+
+    deflections_memo.deflections_yx_2d_from(profile, grid, np)
+    deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    stats = deflections_memo.memo_stats()
+    assert stats["entries"] == 0
+    assert stats["bytes"] == 0
+    assert stats["hits"] == 0
+
+
+def test__profile_holding_a_non_scalar_attribute_falls_through():
+    grid = grid_2d()
+
+    profile = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=1.0)
+    profile.einstein_radius = np.array([1.0, 2.0])
+
+    result = deflections_memo.deflections_yx_2d_from(profile, grid, np)
+
+    assert deflections_memo.memo_stats() == {
+        "hits": 0,
+        "misses": 0,
+        "evictions": 0,
+        "bytes": 0,
+        "entries": 0,
+    }
+    assert result is not None
+
+    # A `Basis`, whose constructor argument is a list of profiles, is unmemoisable in
+    # its own right -- its members are memoised individually instead.
+    basis = ag.lp_basis.Basis(profile_list=[gaussian()])
+    deflections_memo.deflections_yx_2d_from(basis, grid, np)
+
+    assert deflections_memo.memo_stats()["entries"] == 1
+
+
+def test__galaxy_sum_matches_the_sum_with_the_memo_off(monkeypatch):
+    grid = grid_2d()
+
+    galaxy = ag.Galaxy(
+        redshift=0.5,
+        mass=ag.mp.Isothermal(
+            centre=(0.0, 0.0), ell_comps=(0.1, 0.1), einstein_radius=1.2
+        ),
+        stellar=gaussian(mass_to_light_ratio=2.5),
+    )
+
+    monkeypatch.setenv("AUTOGALAXY_DEFLECTIONS_MEMO", "0")
+    off = galaxy.deflections_yx_2d_from(grid=grid)
+
+    monkeypatch.setenv("AUTOGALAXY_DEFLECTIONS_MEMO", "1")
+    galaxy.deflections_yx_2d_from(grid=grid)
+    on = galaxy.deflections_yx_2d_from(grid=grid)
+
+    assert deflections_memo.memo_stats()["hits"] == 2
+    assert values(on) == pytest.approx(values(off), rel=1e-12, abs=0.0)
+
+
+def test__basis_sum_matches_the_sum_with_the_memo_off(monkeypatch):
+    grid = grid_2d()
+
+    def basis(mass_to_light_ratio):
+        return ag.lp_basis.Basis(
+            profile_list=[
+                ag.lmp.Gaussian(
+                    centre=(0.0, 0.0),
+                    ell_comps=(0.05, 0.1),
+                    intensity=1.0,
+                    sigma=sigma,
+                    mass_to_light_ratio=mass_to_light_ratio,
+                )
+                for sigma in (0.3, 0.9, 2.1)
+            ]
+        )
+
+    monkeypatch.setenv("AUTOGALAXY_DEFLECTIONS_MEMO", "0")
+    off = basis(2.5).deflections_yx_2d_from(grid=grid)
+
+    monkeypatch.setenv("AUTOGALAXY_DEFLECTIONS_MEMO", "1")
+    basis(1.0).deflections_yx_2d_from(grid=grid)
+    on = basis(2.5).deflections_yx_2d_from(grid=grid)
+
+    assert deflections_memo.memo_stats()["hits"] == 3
+    assert deflections_memo.memo_stats()["misses"] == 3
+    assert values(on) == pytest.approx(values(off), rel=1e-12, abs=0.0)


### PR DESCRIPTION
## Summary
Closes #601 — phase 1 of the `gaussian-deflections-precompute` epic (successor to `numpy-deflections-cpu`).

In the SLaM `mass_light_dark` stage every Gaussian of an MGE lens light is fixed (centre, `ell_comps`, `sigma`, `intensity` from the light-stage instance) and the stack shares one free `mass_to_light_ratio`, yet every likelihood call re-evaluates each Gaussian's Faddeeva field. The deflections are exactly linear in the ratio, so this PR adds a private cross-evaluation memo, `autogalaxy/profiles/mass/abstract/deflections_memo.py`, and routes the per-profile calls at the two summation sites (`Galaxy.deflections_yx_2d_from`, `Basis.deflections_yx_2d_from`) through it:

- **L1** — any mass profile whose constructor arguments are all scalars stores its final (y,x) field keyed on (class, argument values, grid content) and returns it on a hit, re-wrapped by the same maker `@to_vector_yx` uses.
- **L2** — `mp.Gaussian` and the `lmp` / `lmp_linear` Gaussians that inherit its deflections key past `mass_to_light_ratio`, store the unit-ratio field (evaluated on a shallow copy with ratio 1.0) and return `ratio × field` on every call. `GaussianGradient` is not linear in one scalar and takes L1 only.
- Grids are keyed on **content** (sha256 of the coordinate bytes + type, shape, dtype, `pixel_scales`, `origin`), because `FitDataset.grids` rebuilds the grid every likelihood call; a shifted or rotated grid misses by construction. A small `id(grid) → (weakref, fingerprint)` cache makes the hash a once-per-evaluation cost (936 µs cold, 0.55 µs cached on the hst 15,361-point grid).
- Byte-capped FIFO (default 256 MB, `AUTOGALAXY_DEFLECTIONS_MEMO_MAX_MB`), kill switch `AUTOGALAXY_DEFLECTIONS_MEMO=0`, in-process `memo_disabled()` context manager, `memo_stats()` / `memo_clear()`. Stored arrays are read-only copies. Anything that cannot be keyed exactly (non-scalar constructor argument, `**kwargs` constructor, JAX tracer, grid without a numpy array) falls through — misses, never stale hits. The memo engages only when `xp is np`; the JAX path is untouched.

Measured (autolens_profiling, quiet host, `OMP_NUM_THREADS=1`; the measurement of record lands in the companion autolens_profiling PR): a `Basis` of 30 fixed `lmp.Gaussian`s with one shared ratio on the hst grid **135.6 → 6.3 ms per call (21.5×)**, euclid **33.6 → 2.5 ms (13.5×)**; the `_wofz` call counter over three consecutive evaluations is `[60, 0, 0]` with fixed geometry and `[60, 60, 60]` under both controls (geometry varied per call; kill switch). A SLaM-shaped numba imaging likelihood (30 fixed linear Gaussians + one ratio, NFWSph + shear, rectangular source) **0.583 → 0.195 s per evaluation (3.0×)** with a bit-identical log-likelihood. L1 is bit-identical; L2 differs from a direct call by one multiplication order — max relative 2.4e-13.

## API Changes
None — internal changes only. One private module and two env switches; no public signature or behaviour change on a miss.
See full details below.

## Test Plan
- [x] `test_autogalaxy` — 1176 passed (`-n 4`), including 15 new tests in `test_autogalaxy/profiles/mass/abstract/test_deflections_memo.py`: hit/miss on repeated values; L2 exactness vs direct call (rtol 1e-12) for `mp.Gaussian` and an `lmp` Gaussian; `GaussianGradient` takes L1; grid-content keying (fresh `Grid2D` with the same coordinates hits, a different origin misses, `Grid2DIrregular` does not collide); kill switch; byte-cap eviction; unmemoisable profile falls through; `Galaxy` / `Basis` sums equal with the memo on and off
- [x] No `jax` import in any unit test
- [x] autolens_profiling `scripts/lens/deflections/{total,dark,stellar}.py` pins held at rtol 1e-6 on hst + euclid, no re-pin (the driver measures memo-off by design); numba likelihood pins untouched
- [x] `ruff check` / `ruff format --check` clean

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- none

### Added
- `autogalaxy.profiles.mass.abstract.deflections_memo` — private module: `deflections_yx_2d_from(profile, grid, xp=np)`, `memo_enabled()`, `memo_disabled()` (context manager), `memo_stats()`, `memo_clear()`, `memo_max_bytes()`
- env `AUTOGALAXY_DEFLECTIONS_MEMO=0` (kill switch), `AUTOGALAXY_DEFLECTIONS_MEMO_MAX_MB` (byte cap, default 256)

### Changed Behaviour
- `Galaxy.deflections_yx_2d_from` and `Basis.deflections_yx_2d_from` (numpy path) reuse a fixed-geometry profile's deflection field across calls; results are identical to the direct call (L1 bit-identical, L2 ≤ 2.4e-13 relative)

### Migration
- none

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhnA4pFN2NycuKc8Ni6s2R
