### PR TITLE
docs: human-readable documentation first, AI assistant second

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@
 
 ## Getting Started
 
-### PyAutoGalaxy AI Assistant
-
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
-
 ### Human-Readable Documentation and Examples
 
 The following human-readable documentation and examples are also useful for new starters:
@@ -39,6 +35,12 @@ The following human-readable documentation and examples are also useful for new 
 - [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.8.29.1/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
 - [The autogalaxy_workspace GitHub repository](https://github.com/PyAutoLabs/autogalaxy_workspace): example scripts covering every **PyAutoGalaxy** use case.
 - [The HowToGalaxy GitHub repository](https://github.com/PyAutoLabs/HowToGalaxy): a Jupyter notebook lecture series teaching galaxy modeling from the ground up.
+
+### PyAutoGalaxy AI Assistant
+
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+**The PyAutoGalaxy AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
 
 ## Core Aims
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,10 +20,6 @@ substitutions:
 
 # Getting Started
 
-## PyAutoGalaxy AI Assistant
-
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
-
 ## Human-Readable Documentation and Examples
 
 The following human-readable documentation and examples are also useful for new starters:
@@ -32,6 +28,12 @@ The following human-readable documentation and examples are also useful for new 
 - [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.8.29.1/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
 - [The autogalaxy_workspace GitHub repository](https://github.com/PyAutoLabs/autogalaxy_workspace): example scripts covering every **PyAutoGalaxy** use case.
 - [The HowToGalaxy GitHub repository](https://github.com/PyAutoLabs/HowToGalaxy): a Jupyter notebook lecture series teaching galaxy modeling from the ground up.
+
+## PyAutoGalaxy AI Assistant
+
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+**The PyAutoGalaxy AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
 
 # Core Aims
 

--- a/docs/overview/overview_1_start_here.md
+++ b/docs/overview/overview_1_start_here.md
@@ -2,10 +2,6 @@
 
 # Start Here
 
-## PyAutoGalaxy AI Assistant
-
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
-
 ## Human-Readable Overview
 
 **PyAutoGalaxy** is software for analysing the morphologies and structures of galaxies:
@@ -22,6 +18,12 @@ The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_ass
 - **Data Variety**: Support for many data types (e.g. CCD imaging, interferometry, multi-band imaging) which can be fitted independently or simultaneously.
 
 This overview gives an overview of **PyAutoGalaxy**'s API, core features and details of the autogalaxy_workspace.
+
+## PyAutoGalaxy AI Assistant
+
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+**The PyAutoGalaxy AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
 
 ## Imports
 

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -2,10 +2,6 @@
 
 # New User Guide
 
-## PyAutoGalaxy AI Assistant
-
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
-
 ## Human-Readable Guide
 
 **PyAutoGalaxy** can analyse galaxies for different types of data (e.g. CCD imaging and interferometer observations)
@@ -14,6 +10,12 @@ Depending on the data you use and the scale of your system, the analysis you per
 
 The autogalaxy_workspace contains a suite of example Jupyter Notebooks, organised by dataset type and system scale.
 To help you find the most appropriate starting point, answer two simple questions:
+
+## PyAutoGalaxy AI Assistant
+
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+
+**The PyAutoGalaxy AI Assistant currently only supports AI coding agents which require a paid subscription, either Claude Code or Codex. Work is ongoing to support free AI coding agents and conversation agents like ChatGPT.**
 
 ## What Scale System?
 


### PR DESCRIPTION
## Summary
Swaps the Getting Started order back to human-readable documentation first, AI Assistant second — reverting the order introduced by the July "assistant-first" docs PRs. Section text is unchanged; only the order moves. Adds a bold note under the AI Assistant section that only the paid coding agents (Claude Code / Codex) are currently supported, with free coding agents and conversation agents in progress.

Part of PyAutoLabs/autolens_assistant#120 (six-repo docs change, PR-open only — merge is a human decision).

## API Changes
None — documentation only. Files touched:
- `README.md`
- `docs/index.md`
- `docs/overview/overview_1_start_here.md`
- `docs/overview/overview_2_new_user_guide.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRKarVxARKJ6VJN5Qc3521