### PR TITLE
fix: write dataset.fits once, always, to image/ (drop fits_dataset knob)

### DIFF
--- a/autogalaxy/analysis/analysis/dataset.py
+++ b/autogalaxy/analysis/analysis/dataset.py
@@ -127,10 +127,11 @@ class AnalysisDataset(Analysis):
         - The settings associated with the pixelization.
         - The Cosmology.
 
+        The dataset itself is output as `dataset.fits` to the `image` folder by the `save_attributes` method of
+        each dataset-specific subclass (e.g. `AnalysisImaging`), with the mask in its `PrimaryHDU`.
+
         The following .fits files are also output via the plotter interface:
 
-        - The mask applied to the dataset, in the `PrimaryHDU` of `dataset.fits`.
-        - The dataset (data / noise-map / over sampler / etc.).
         - The adapt image's model image and galaxy images, if used.
 
         It is common for these attributes to be loaded by many of the template aggregator functions given in the

--- a/autogalaxy/config/visualize/plots.yaml
+++ b/autogalaxy/config/visualize/plots.yaml
@@ -3,19 +3,20 @@
 # For example, if `plots: fit: subplot_fit=True``, the ``subplot_fit.png`` subplot file will
 # be plotted every time visualization is performed.
 
-# There are two settings which are important for inspecting results via the dataset after a fit is complete which are:
+# One setting is important for inspecting results via the dataset after a fit is complete:
 
-# - `fits_dataset`: This outputs `dataset.fits` which the database functionality may use to reperform fits.
 # -`fits_adapt_images`, This outputs `adapt_images.fits` which the database functionality may use to reperform fits.
 
-# These can be disabled to save on hard-disk space but will lead to certain database functionality being disabled.
+# It can be disabled to save on hard-disk space but will lead to certain database functionality being disabled.
+
+# The dataset itself is always output as `dataset.fits` to the `image` folder of every fit, and is not controlled
+# by any setting here.
 
 subplot_format: [png]                      # Output format of all subplots, can be png, pdf or both (e.g. [png, pdf])
 fits_are_zoomed: false                     # If true, output .fits files are zoomed in on the center of the unmasked region image, saving hard-disk space.
 
 dataset:                                   # Settings for plots of all datasets (e.g. Imaging, Interferometer).
   subplot_dataset: true                    # Plot subplot containing all dataset quantities (e.g. the data, noise-map, etc.)?
-  fits_dataset: true                      # Output a .fits file containing the dataset data, noise-map and other quantities?
 
 fit:                                       # Settings for plots of all fits (e.g. FitImaging, FitInterferometer).
   subplot_fit: true                        # Plot subplot of all fit quantities for any dataset (e.g. the model data, residual-map, etc.)?

--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -237,10 +237,10 @@ class AnalysisImaging(AnalysisDataset):
         - The Cosmology.
         - The adapt image's model image and galaxy images, as `adapt_images.fits`, if used.
 
-        The following .fits files are also output via the plotter interface:
+        It also outputs, to the `image` folder, the file `dataset.fits`, which contains:
 
-        - The mask applied to the dataset, in the `PrimaryHDU` of `dataset.fits`.
-        - The imaging dataset as `dataset.fits` (data / noise-map / psf / over sampler / etc.).
+        - The mask applied to the dataset, in the `PrimaryHDU`.
+        - The imaging dataset (data / noise-map / psf / over sampler / etc.).
 
         It is common for these attributes to be loaded by many of the template aggregator functions given in the
         `aggregator` modules. For example, when using the database tools to perform a fit, the default behaviour is for
@@ -255,12 +255,6 @@ class AnalysisImaging(AnalysisDataset):
         """
         super().save_attributes(paths=paths)
 
-        # Output `dataset.fits` to the `files` folder so the aggregator loaders
-        # (e.g. `ImagingAgg`, `agg_util.mask_header_from`) can always reload the
-        # dataset via `fit.value(name="dataset")`, independently of whether the
-        # visualization `fits_dataset` output ran. The plotter interface also
-        # writes this file to the `image` folder for inspection, but that write
-        # is gated on visualization settings and is not guaranteed for every fit.
         image_list = [
             self.dataset.data.native_for_fits,
             self.dataset.noise_map.native_for_fits,
@@ -271,18 +265,27 @@ class AnalysisImaging(AnalysisDataset):
             ),
         ]
 
-        paths.save_fits(
-            name="dataset",
-            fits=hdu_list_for_output_from(
-                values_list=[image_list[0].mask.astype("float")] + image_list,
-                ext_name_list=[
-                    "mask",
-                    "data",
-                    "noise_map",
-                    "psf",
-                    "over_sample_size_lp",
-                    "over_sample_size_pixelization",
-                ],
-                header_dict=self.dataset.mask.header_dict,
-            ),
+        hdu_list = hdu_list_for_output_from(
+            values_list=[image_list[0].mask.astype("float")] + image_list,
+            ext_name_list=[
+                "mask",
+                "data",
+                "noise_map",
+                "psf",
+                "over_sample_size_lp",
+                "over_sample_size_pixelization",
+            ],
+            header_dict=self.dataset.mask.header_dict,
         )
+
+        # `dataset.fits` is written once per search, to the `image` folder, and is written
+        # unconditionally (it is not gated on any visualization setting). The write is skipped
+        # if the file already exists, so a resumed search does not rewrite it.
+        #
+        # The aggregator loaders (e.g. `ImagingAgg`, `agg_util.mask_header_from`) reload the
+        # dataset via `fit.value(name="dataset")`, which scans the `image` folder for .fits
+        # files, so this single write is all that is required.
+        dataset_path = paths.image_path / "dataset.fits"
+
+        if not dataset_path.exists():
+            hdu_list.writeto(dataset_path, overwrite=True)

--- a/autogalaxy/imaging/model/plotter.py
+++ b/autogalaxy/imaging/model/plotter.py
@@ -1,7 +1,5 @@
 from typing import List
 
-from autonerves.fitsable import hdu_list_for_output_from
-
 import autoarray as aa
 
 from autoarray.dataset.plot.imaging_plots import subplot_imaging_dataset, subplot_imaging_dataset_list
@@ -23,9 +21,7 @@ class PlotterImaging(Plotter):
         Output visualization of an ``Imaging`` dataset.
 
         Controlled by the ``[dataset]`` / ``[imaging]`` sections of
-        ``config/visualize/plots.yaml``.  Outputs a subplot of the imaging data
-        and, when enabled, a FITS file containing the mask, data, noise map, PSF,
-        and over-sample-size arrays.
+        ``config/visualize/plots.yaml``.  Outputs a subplot of the imaging data.
 
         Parameters
         ----------
@@ -42,23 +38,6 @@ class PlotterImaging(Plotter):
                 output_format=self.fmt,
                 title_prefix=self.title_prefix,
             )
-
-        if should_plot("fits_dataset"):
-            image_list = [
-                dataset.data.native_for_fits,
-                dataset.noise_map.native_for_fits,
-                dataset.psf.kernel.native_for_fits,
-                dataset.grids.lp.over_sample_size.native_for_fits.astype("float"),
-                dataset.grids.pixelization.over_sample_size.native_for_fits.astype("float"),
-            ]
-
-            hdu_list = hdu_list_for_output_from(
-                values_list=[image_list[0].mask.astype("float")] + image_list,
-                ext_name_list=["mask", "data", "noise_map", "psf",
-                               "over_sample_size_lp", "over_sample_size_pixelization"],
-                header_dict=dataset.mask.header_dict,
-            )
-            hdu_list.writeto(self.image_path / "dataset.fits", overwrite=True)
 
     def fit_imaging(self, fit: FitImaging, quick_update: bool = False):
         """

--- a/autogalaxy/interferometer/model/analysis.py
+++ b/autogalaxy/interferometer/model/analysis.py
@@ -229,10 +229,10 @@ class AnalysisInterferometer(AnalysisDataset):
         - The Cosmology.
         - The adapt image's model image and galaxy images, as `adapt_images.fits`, if used.
 
-        The following .fits files are also output via the plotter interface:
+        It also outputs, to the `image` folder, the file `dataset.fits`, which contains:
 
-        - The real space mask applied to the dataset, in the `PrimaryHDU` of `dataset.fits`.
-        - The interferometer dataset as `dataset.fits` (data / noise-map / uv_wavelengths).
+        - The real space mask applied to the dataset, in the `PrimaryHDU`.
+        - The interferometer dataset (data / noise-map / uv_wavelengths).
 
         It is common for these attributes to be loaded by many of the template aggregator functions given in the
         `aggregator` modules. For example, when using the database tools to perform a fit, the default behaviour is for
@@ -247,26 +247,28 @@ class AnalysisInterferometer(AnalysisDataset):
         """
         super().save_attributes(paths=paths)
 
-        # Output `dataset.fits` to the `files` folder so the aggregator loaders
-        # (e.g. `InterferometerAgg`, `agg_util.mask_header_from`) can always
-        # reload the dataset via `fit.value(name="dataset")`, independently of
-        # whether the visualization `fits_dataset` output ran. The plotter
-        # interface also writes this file to the `image` folder for inspection,
-        # but that write is gated on visualization settings and is not
-        # guaranteed for every fit.
-        paths.save_fits(
-            name="dataset",
-            fits=hdu_list_for_output_from(
-                values_list=[
-                    self.dataset.real_space_mask.astype("float"),
-                    self.dataset.data.in_array,
-                    self.dataset.noise_map.in_array,
-                    self.dataset.uv_wavelengths,
-                ],
-                ext_name_list=["mask", "data", "noise_map", "uv_wavelengths"],
-                header_dict=self.dataset.real_space_mask.header_dict,
-            ),
+        hdu_list = hdu_list_for_output_from(
+            values_list=[
+                self.dataset.real_space_mask.astype("float"),
+                self.dataset.data.in_array,
+                self.dataset.noise_map.in_array,
+                self.dataset.uv_wavelengths,
+            ],
+            ext_name_list=["mask", "data", "noise_map", "uv_wavelengths"],
+            header_dict=self.dataset.real_space_mask.header_dict,
         )
+
+        # `dataset.fits` is written once per search, to the `image` folder, and is written
+        # unconditionally (it is not gated on any visualization setting). The write is skipped
+        # if the file already exists, so a resumed search does not rewrite it.
+        #
+        # The aggregator loaders (e.g. `InterferometerAgg`, `agg_util.mask_header_from`) reload
+        # the dataset via `fit.value(name="dataset")`, which scans the `image` folder for .fits
+        # files, so this single write is all that is required.
+        dataset_path = paths.image_path / "dataset.fits"
+
+        if not dataset_path.exists():
+            hdu_list.writeto(dataset_path, overwrite=True)
 
         paths.save_json(
             "transformer_class",

--- a/autogalaxy/interferometer/model/plotter.py
+++ b/autogalaxy/interferometer/model/plotter.py
@@ -2,8 +2,6 @@ import autoarray as aa
 
 from autoarray.dataset.plot.interferometer_plots import subplot_interferometer_dataset
 
-from autonerves.fitsable import hdu_list_for_output_from
-
 from autogalaxy.interferometer.fit_interferometer import FitInterferometer
 from autogalaxy.interferometer.plot import fit_interferometer_plots
 from autogalaxy.interferometer.plot.fit_interferometer_plots import (
@@ -19,9 +17,7 @@ class PlotterInterferometer(Plotter):
         Output visualization of an ``Interferometer`` dataset.
 
         Controlled by the ``[dataset]`` / ``[interferometer]`` sections of
-        ``config/visualize/plots.yaml``.  Outputs a dirty-image subplot and,
-        when enabled, a FITS file containing the mask, visibilities, noise map,
-        and UV-wavelengths arrays.
+        ``config/visualize/plots.yaml``.  Outputs a dirty-image subplot.
 
         Parameters
         ----------
@@ -39,21 +35,6 @@ class PlotterInterferometer(Plotter):
                 output_format=self.fmt[0] if isinstance(self.fmt, (list, tuple)) else self.fmt,
                 title_prefix=self.title_prefix,
             )
-
-        if should_plot("fits_dataset"):
-
-            hdu_list = hdu_list_for_output_from(
-                values_list=[
-                    dataset.real_space_mask.astype("float"),
-                    dataset.data.in_array,
-                    dataset.noise_map.in_array,
-                    dataset.uv_wavelengths,
-                ],
-                ext_name_list=["mask", "data", "noise_map", "uv_wavelengths"],
-                header_dict=dataset.real_space_mask.header_dict,
-            )
-
-            hdu_list.writeto(self.image_path / "dataset.fits", overwrite=True)
 
     def fit_interferometer(
         self,

--- a/test_autogalaxy/analysis/analysis/test_analysis.py
+++ b/test_autogalaxy/analysis/analysis/test_analysis.py
@@ -49,22 +49,67 @@ def test__save_results__galaxies_output_to_json(analysis_imaging_7x7):
 
 def test__save_attributes__dataset_fits_output_for_aggregator(analysis_imaging_7x7):
     # Regression guard: `save_attributes` must always write `dataset.fits` to the
-    # `files` folder so the aggregator loaders (`ImagingAgg`,
+    # `image` folder so the aggregator loaders (`ImagingAgg`,
     # `agg_util.mask_header_from`) can reload the dataset via
-    # `fit.value(name="dataset")`, independently of whether visualization ran.
+    # `fit.value(name="dataset")`. The write is not gated on visualization.
     from astropy.io import fits
 
     paths = af.DirectoryPaths()
 
+    dataset_fits_path = paths.image_path / "dataset.fits"
+
+    if dataset_fits_path.exists():
+        os.remove(dataset_fits_path)
+
     analysis_imaging_7x7.save_attributes(paths=paths)
 
-    dataset_fits_path = paths._files_path / "dataset.fits"
-
     assert dataset_fits_path.exists()
+    assert not (paths._files_path / "dataset.fits").exists()
 
     with fits.open(dataset_fits_path) as hdu_list:
         ext_names = [hdu.name for hdu in hdu_list]
 
     assert ext_names[:4] == ["MASK", "DATA", "NOISE_MAP", "PSF"]
+
+    # A second call (e.g. a resumed search) must not rewrite the existing file.
+
+    dataset_fits_path.write_bytes(b"sentinel")
+
+    analysis_imaging_7x7.save_attributes(paths=paths)
+
+    assert dataset_fits_path.read_bytes() == b"sentinel"
+
+    os.remove(dataset_fits_path)
+
+
+def test__save_attributes__dataset_fits_output_for_aggregator__interferometer(
+    analysis_interferometer_7,
+):
+    from astropy.io import fits
+
+    paths = af.DirectoryPaths()
+
+    dataset_fits_path = paths.image_path / "dataset.fits"
+
+    if dataset_fits_path.exists():
+        os.remove(dataset_fits_path)
+
+    analysis_interferometer_7.save_attributes(paths=paths)
+
+    assert dataset_fits_path.exists()
+    assert not (paths._files_path / "dataset.fits").exists()
+
+    with fits.open(dataset_fits_path) as hdu_list:
+        ext_names = [hdu.name for hdu in hdu_list]
+
+    assert ext_names[:4] == ["MASK", "DATA", "NOISE_MAP", "UV_WAVELENGTHS"]
+
+    # A second call (e.g. a resumed search) must not rewrite the existing file.
+
+    dataset_fits_path.write_bytes(b"sentinel")
+
+    analysis_interferometer_7.save_attributes(paths=paths)
+
+    assert dataset_fits_path.read_bytes() == b"sentinel"
 
     os.remove(dataset_fits_path)

--- a/test_autogalaxy/imaging/model/test_plotter_imaging.py
+++ b/test_autogalaxy/imaging/model/test_plotter_imaging.py
@@ -23,12 +23,6 @@ def test__imaging(imaging_7x7, plot_path, plot_patch):
 
     assert str(Path(plot_path) / "dataset.png") in plot_patch.paths
 
-    image = ag.ndarray_via_fits_from(
-        file_path=Path(plot_path) / "dataset.fits", hdu=1
-    )
-
-    assert image.shape == (7, 7)
-
 
 def test__imaging_combined(imaging_7x7, plot_path, plot_patch):
     if Path(plot_path).exists():

--- a/test_autogalaxy/interferometer/model/test_plotter_interferometer.py
+++ b/test_autogalaxy/interferometer/model/test_plotter_interferometer.py
@@ -22,12 +22,6 @@ def test__interferometer(interferometer_7, plot_path, plot_patch):
 
     assert str(Path(plot_path) / "dataset.png") in plot_patch.paths
 
-    image = ag.ndarray_via_fits_from(
-        file_path=Path(plot_path) / "dataset.fits", hdu=1
-    )
-
-    assert image.shape == (7, 2)
-
 
 def test__fit_interferometer(
     interferometer_7,


### PR DESCRIPTION
## Summary
Every imaging and interferometer search has written `dataset.fits` twice since #479: `files/dataset.fits` unconditionally from `save_attributes` (via `paths.save_fits`), and an identical `image/dataset.fits` from the plotter interface gated on `visualize/plots.yaml` `dataset.fits_dataset`. Spotted in a Euclid `vis_lp` output folder; generic library behaviour.

This PR makes `dataset.fits` a single, always-written file under `image/`: `AnalysisImaging.save_attributes` and `AnalysisInterferometer.save_attributes` write it directly to `paths.image_path` and skip the write when the file already exists (a resumed search does not rewrite it). The `fits_dataset`-gated plotter writes and the `fits_dataset` config key are removed. `autofit.aggregator.SearchOutput` already scans `image/` for `.fits`, so `fit.value(name="dataset")` and the `*Agg` loaders are unchanged.

Not touched: PyAutoFit. Known trade-off: `DatabasePaths.save_fits` no longer receives `dataset` from `save_attributes` (the pre-#479 behaviour); an image-folder-aware `save_fits` in PyAutoFit can follow if the database route needs it.

Closes #608.

## API Changes
- `visualize/plots.yaml` `dataset.fits_dataset` is removed — `dataset.fits` is always written, once, to the search's `image/` folder. Workspace `config/visualize/plots.yaml` copies should drop the key (workspace follow-up PRs).
- `dataset.fits` is no longer written to `files/`; readers that hard-coded `files/dataset.fits` should read `image/dataset.fits` (the aggregator needs no change).
See full details below.

## Test Plan
- [ ] `pytest test_autogalaxy/analysis test_autogalaxy/imaging/model test_autogalaxy/interferometer/model test_autogalaxy/ellipse`
- [ ] A fit's output has exactly one `dataset.fits`, under `image/`, none under `files/`
- [ ] `af.Aggregator.from_directory(...)` + `ag.agg.ImagingAgg(agg).dataset_gen_from()` round-trips the dataset

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Removed
- `config/visualize/plots.yaml` key `dataset.fits_dataset` — the output is unconditional now.
- `PlotterImaging.imaging` / `PlotterInterferometer.interferometer` no longer write `dataset.fits` (moved to `save_attributes`).

### Changed
- `AnalysisImaging.save_attributes`, `AnalysisInterferometer.save_attributes` — write `image/dataset.fits` (was `files/dataset.fits`), skipped when the file exists.

### Migration
- Before: `dataset.fits` under both `files/` and `image/`; `fits_dataset: true` in `plots.yaml`.
- After: `image/dataset.fits` only; delete the `fits_dataset` line from any copied `plots.yaml`.

</details>

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Giskz46AjniG7E9dKxwpTG
