### PR TITLE
docs: agentic-only wording for the AI Assistant note

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ The following human-readable documentation and examples are useful for new start
 
 ### PyAutoGalaxy AI Assistant
 
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) lets you do galaxy structure and morphology science in natural language from inside an AI coding agent. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
 
-**The PyAutoGalaxy AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
+**The assistant runs inside an AI coding agent: Claude Code or Codex are recommended. Sustained scientific use normally needs paid access to one of them (a personal subscription, institutional access or API billing). OpenCode is an experimental alternative whose client is free but whose model access, cost and capability depend on the provider. Browser chat routes (ChatGPT or Claude with a GitHub connector) are no longer supported.**
 
 ## Core Aims
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,9 +31,9 @@ The following human-readable documentation and examples are useful for new start
 
 ## PyAutoGalaxy AI Assistant
 
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) lets you do galaxy structure and morphology science in natural language from inside an AI coding agent. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
 
-**The PyAutoGalaxy AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
+**The assistant runs inside an AI coding agent: Claude Code or Codex are recommended. Sustained scientific use normally needs paid access to one of them (a personal subscription, institutional access or API billing). OpenCode is an experimental alternative whose client is free but whose model access, cost and capability depend on the provider. Browser chat routes (ChatGPT or Claude with a GitHub connector) are no longer supported.**
 
 # Core Aims
 

--- a/docs/overview/overview_1_start_here.md
+++ b/docs/overview/overview_1_start_here.md
@@ -21,9 +21,9 @@ This overview gives an overview of **PyAutoGalaxy**'s API, core features and det
 
 ## PyAutoGalaxy AI Assistant
 
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) lets you do galaxy structure and morphology science in natural language from inside an AI coding agent. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
 
-**The PyAutoGalaxy AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
+**The assistant runs inside an AI coding agent: Claude Code or Codex are recommended. Sustained scientific use normally needs paid access to one of them (a personal subscription, institutional access or API billing). OpenCode is an experimental alternative whose client is free but whose model access, cost and capability depend on the provider. Browser chat routes (ChatGPT or Claude with a GitHub connector) are no longer supported.**
 
 ## Imports
 

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -13,9 +13,9 @@ To help you find the most appropriate starting point, answer two simple question
 
 ## PyAutoGalaxy AI Assistant
 
-The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) supports conversation agents such as ChatGPT and coding agents such as Claude Code and Codex. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
+The [**PyAutoGalaxy AI Assistant**](https://github.com/PyAutoLabs/autogalaxy_assistant) lets you do galaxy structure and morphology science in natural language from inside an AI coding agent. You can get started simply by asking it a question about galaxy structure or describing the task you would like to perform with **PyAutoGalaxy**. See the assistant for its full scope and instructions.
 
-**The PyAutoGalaxy AI Assistant currently requires a paid subscription: Claude Code or Codex as a coding agent, or ChatGPT or Claude on a paid plan as a conversation assistant. Free options are being tested.**
+**The assistant runs inside an AI coding agent: Claude Code or Codex are recommended. Sustained scientific use normally needs paid access to one of them (a personal subscription, institutional access or API billing). OpenCode is an experimental alternative whose client is free but whose model access, cost and capability depend on the provider. Browser chat routes (ChatGPT or Claude with a GitHub connector) are no longer supported.**
 
 ## What Scale System?
 


### PR DESCRIPTION
## Summary

Docs only. The AI Assistant note in `README.md`, `docs/index.md` and both overview pages no longer says the assistant supports conversation agents such as ChatGPT or that it requires a paid subscription. It now states the agentic-only policy adopted in PyAutoLabs/autogalaxy_assistant: the assistant runs inside an AI coding agent (Claude Code or Codex recommended), sustained use normally needs paid access via a subscription, institutional access or API billing, OpenCode is an experimental alternative, and browser-chat routes are no longer supported.

## Test plan

- [ ] CI docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsLuCV9nbPPUWBK9rewCZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsLuCV9nbPPUWBK9rewCZe)_